### PR TITLE
OpenAPI integration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to ctricto
+# Contributing to btricto
 
 Help wanted! We'd love your contributions to backo. Please review the following guidelines before contributing. Also, feel free to propose changes to these guidelines by updating this file and submitting a pull request.
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ my_backoffice.build_routes(flask)
 
 It represents a database entity and includes all the methods required for CRUD operations: *Create*, *Read*, *Update*, and *Delete*.
 
-A generic object is a [stricto](https://github.com/bwallrich/stricto) `Dict()` object.
+A generic object is a [stricto](https://github.com/backo-stricto/stricto) `Dict()` object.
 
 
 
@@ -208,11 +208,11 @@ Relations cardinalities are expressed by the mean of `Ref()` and `RefsList()`:
 | Option for Ref | Default | Description |
 | - | - | - |
 | <kbd>coll=</kbd> | None | the collection to make the ref |
-| <kbd>field=</kbd> | None | The reverse field in the targeted collection (use [selector](https://github.com/bwallrich/stricto?tab=readme-ov-file#selectors) to target it) |
+| <kbd>field=</kbd> | None | The reverse field in the targeted collection (use [selector](https://github.com/backo-stricto/stricto?tab=readme-ov-file#selectors) to target it) |
 | <kbd>ods=</kbd> | ```DeleteStrategy.MUST_BE_EMPTY``` | *On Delete Strategy* see [ods](#deletion-strategies-ods)|
 | <kbd>ofs=</kbd> | ```FillStrategy.FILL``` | *On Fill Strategy* |
 
-And all options availables in [stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string) fields.
+And all options availables in [stricto String()](https://github.com/backo-stricto/stricto?tab=readme-ov-file#string) fields.
 
 
 #### Deletion strategies (`ods`)
@@ -258,7 +258,7 @@ a_book = Item({
 
 ## Files objects
 
-backo can manage files in a simple way : Like other [stricto types](https://github.com/bwallrich/stricto?tab=readme-ov-file#basic-types).
+backo can manage files in a simple way : Like other [stricto types](https://github.com/backo-stricto/stricto?tab=readme-ov-file#basic-types).
 You can use File() or BlobFile().
 
 | object | Description |
@@ -266,7 +266,7 @@ You can use File() or BlobFile().
 | File() | Generic object to manage a file. You need to define a FileConnector to indicate the object File where to store the file |
 | BlobFile() | File data is integrated literally into the datastructure, so there is no need for a FileConnector. Reserved for small files. |
 
-You can use all [parameters](https://github.com/bwallrich/stricto?tab=readme-ov-file#types) for Files like other fields. 
+You can use all [parameters](https://github.com/backo-stricto/stricto?tab=readme-ov-file#types) for Files like other fields. 
 
 
 However there are extra specific parameters :
@@ -431,7 +431,7 @@ def your_function_name(right_name: str, o: Item) -> bool:
 An action represent some modifications to an Item witch is more complex than just a PATCH/PUT (modification).
 
 An action is compose by :
-1. an [Stricto Dict](https://github.com/bwallrich/stricto?tab=readme-ov-file#dict)
+1. an [Stricto Dict](https://github.com/backo-stricto/stricto?tab=readme-ov-file#dict)
 2. a function
 3. Some rights
 
@@ -509,11 +509,11 @@ See [actions routes](#actions-routes) for resulting RESTful API routes.
 ## Selection
 
 
-A selection is a *named* list of Items with sub elements provided by a [path](https://github.com/bwallrich/stricto#selectors).
+A selection is a *named* list of Items with sub elements provided by a [path](https://github.com/backo-stricto/stricto#selectors).
 
 An selection is compose by :
-1. a list of [selectors](https://github.com/bwallrich/stricto#selectors)
-2. a [filter](https://github.com/bwallrich/stricto#matching)
+1. a list of [selectors](https://github.com/backo-stricto/stricto#selectors)
+2. a [filter](https://github.com/backo-stricto/stricto#matching)
 3. Some rights
 
 > [!IMPORTANT]  
@@ -697,13 +697,13 @@ However, using jwt is a goot solution. See [Authentication](#authentication) for
 
 ### current_user API
 
-`current_user` is a very simple [Stricto Dict](https://github.com/bwallrich/stricto?tab=readme-ov-file#dict) (but can be [extended](#extend-current_user)). It contains :
+`current_user` is a very simple [Stricto Dict](https://github.com/backo-stricto/stricto?tab=readme-ov-file#dict) (but can be [extended](#extend-current_user)). It contains :
 
 | key | type | usage |
 | - | - | - |
-| _id | [Stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string) | the _id of the user. 
-| login | [Stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string) | the login or whatever you store . 
-| roles | [Stricto List( String() )](https://github.com/bwallrich/stricto?tab=readme-ov-file#list) | the list of roles for this users. A *role* is a kid of group the user belongs to | 
+| _id | [Stricto String()](https://github.com/backo-stricto/stricto?tab=readme-ov-file#string) | the _id of the user. 
+| login | [Stricto String()](https://github.com/backo-stricto/stricto?tab=readme-ov-file#string) | the login or whatever you store . 
+| roles | [Stricto List( String() )](https://github.com/backo-stricto/stricto?tab=readme-ov-file#list) | the list of roles for this users. A *role* is a kid of group the user belongs to | 
 | has_role() | function | return True or false to the role givent in param | 
 | reset() | function | change the current_user object type. See [extend current_user](#extend-current_user) for that| 
 
@@ -755,7 +755,7 @@ Api routes are generated
 ### CRUD Routes
 #### GET \<my-app-name\>/\<collection name\>/\<_id\> \?_view=\<view name\>
 
-```_view``` are defined in [stricto views](https://github.com/bwallrich/stricto?tab=readme-ov-file#views)
+```_view``` are defined in [stricto views](https://github.com/backo-stricto/stricto?tab=readme-ov-file#views)
 
 Return the object of this collection *by _id*.
 
@@ -789,12 +789,12 @@ Get a list of objects matching the query string. The query string can be with th
 | \<field\>.\<subfield\> | \<value\> | Matches items where `<field>` is a nested dictionary containing `<subfield>` equal to `<value>`. Example: `address.number=1` matches items where address.number equals to 1. |
 
 
-[list of available operators](https://github.com/bwallrich/stricto?tab=readme-ov-file#filtering-and-matching)
+[list of available operators](https://github.com/backo-stricto/stricto?tab=readme-ov-file#filtering-and-matching)
 
 
 | key | value | default | description |
 | - | - | - | - |
-| \_view | string | "client" | selects the view ([stricto views](https://github.com/bwallrich/stricto?tab=readme-ov-file#views))  |
+| \_view | string | "client" | selects the view ([stricto views](https://github.com/backo-stricto/stricto?tab=readme-ov-file#views))  |
 | \_page | int | - | sets the desired number of items per page in paginated data presentation |
 | \_skip | int | - | skips the n-first items of the result list in paginated data presentation. |
 
@@ -866,7 +866,7 @@ Delete the user that has _id = *1234*.
 
 #### PATCH /\<my-app-name\>/\<collection name\>/\<_id\>
 Partial change of an existing object whose id is `_id`.
-Please refer to the [Stricto patch method](https://github.com/bwallrich/stricto?tab=readme-ov-file#patch).
+Please refer to the [Stricto patch method](https://github.com/backo-stricto/stricto?tab=readme-ov-file#patch).
 
 ##### Example
 ```bash
@@ -883,14 +883,14 @@ Patch content can be a *list of patch operations*.
 
 Check the validity of an item field.
 
-Please refer to [stricto selectors](https://github.com/bwallrich/stricto#selectors) for more details on selectors.
+Please refer to [stricto selectors](https://github.com/backo-stricto/stricto#selectors) for more details on selectors.
 
 get must provide a json structure in the body :
 
 | field | type | descrimtion |
 | -- | -- | -- |
 | item | dict | the data to check. It can be partial, see examples belowv |
-| path | string | the field to check in the item. This is a selector. Please refer to [stricto selectors](https://github.com/bwallrich/stricto#selectors) for more details |
+| path | string | the field to check in the item. This is a selector. Please refer to [stricto selectors](https://github.com/backo-stricto/stricto#selectors) for more details |
 
 The answer is a status 200 message with a json structure :
 
@@ -995,9 +995,9 @@ Describe an element (an item, a key in an item)
 | transform | boolean | say there is a transformation function |
 | exists | boolean | false mean this field does not exist and must not be displayed |
 | rights | [meta rights description](#meta-rights-description) | the description of rights |
-| sub_scheme | [meta element description](#meta-element-description) | reccusive description for childs if this object is a [Dict](https://github.com/bwallrich/stricto?tab=readme-ov-file#dict) or an Item |
-| sub_type | [meta element description](#meta-element-description) | description of the content if this object is a [List](https://github.com/bwallrich/stricto?tab=readme-ov-file#list) |
-| sub_types | array of [meta element description](#meta-element-description) | description of the tuple content if this object is a [Tuple](https://github.com/bwallrich/stricto?tab=readme-ov-file#tuple) |
+| sub_scheme | [meta element description](#meta-element-description) | reccusive description for childs if this object is a [Dict](https://github.com/backo-stricto/stricto?tab=readme-ov-file#dict) or an Item |
+| sub_type | [meta element description](#meta-element-description) | description of the content if this object is a [List](https://github.com/backo-stricto/stricto?tab=readme-ov-file#list) |
+| sub_types | array of [meta element description](#meta-element-description) | description of the tuple content if this object is a [Tuple](https://github.com/backo-stricto/stricto?tab=readme-ov-file#tuple) |
 
 ##### meta rights description
 
@@ -1242,11 +1242,11 @@ moon_address.users # -> return [ astro._id ]
 
 ### _id
 
-You dont't have to care about *_ids* in your item description. Backo will alter schema to add `_id` for each Item (see [stricto schemas](https://github.com/bwallrich/stricto?tab=readme-ov-file#schemas) for details).
+You dont't have to care about *_ids* in your item description. Backo will alter schema to add `_id` for each Item (see [stricto schemas](https://github.com/backo-stricto/stricto?tab=readme-ov-file#schemas) for details).
 
 ### _meta
 
-the db_connector adds meta data to each item by [altering its schema](https://github.com/bwallrich/stricto?tab=readme-ov-file#schemas).
+the db_connector adds meta data to each item by [altering its schema](https://github.com/backo-stricto/stricto?tab=readme-ov-file#schemas).
 
 
 The provided *meta_data_handler* give this Dict() :

--- a/README.md
+++ b/README.md
@@ -164,15 +164,15 @@ backoffice.register_collection( "cats", cats )
 
 ### Methods
 
-| Method | Description |
-| - | - |
-| ```.create( data :dict )``` | Create a new `Item` in the database using the provided `data` dictionary.
-| ```.save()``` | saves the current `Item` to the database. |
-| ```.load( _id :str )``` | loads an `Item` from the database by its `_id`. |
-| ```.reload()``` | reloads the current `Item` from the database. |
-| ```.delete()``` | deletes the current `Item` from the database. |
-| ```.new()``` | creates a new empty `Item` (must be populated with `.set()` and then saved). |
-| ```.select()``` | retrieves a selection of `Item` from the database based on the selection criteria. |
+| Method                      | Description                                                                        |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| ```.create( data :dict )``` | Create a new `Item` in the database using the provided `data` dictionary.          |
+| ```.save()```               | saves the current `Item` to the database.                                          |
+| ```.load( _id :str )```     | loads an `Item` from the database by its `_id`.                                    |
+| ```.reload()```             | reloads the current `Item` from the database.                                      |
+| ```.delete()```             | deletes the current `Item` from the database.                                      |
+| ```.new()```                | creates a new empty `Item` (must be populated with `.set()` and then saved).       |
+| ```.select()```             | retrieves a selection of `Item` from the database based on the selection criteria. |
 
 For each function above, an error is triggered in case of something went wrong.
 
@@ -183,12 +183,12 @@ Relations cardinalities are expressed by the mean of `Ref()` and `RefsList()`:
 
 
 
-| Item A | Item B | description |
-| -- | -- | -- |
-| <kbd>Ref</kbd> | <kbd>Ref</kbd> | 0 or One to one |
-| <kbd>Ref</kbd> | <kbd>RefsList</kbd> | 0 or One to many |
-| <kbd>Ref(require=True)</kbd> | <kbd>RefsList</kbd> | One to many |
-| <kbd>RefsList</kbd> | <kbd>RefsList</kbd> | Many to many |
+| Item A                       | Item B              | description      |
+| ---------------------------- | ------------------- | ---------------- |
+| <kbd>Ref</kbd>               | <kbd>Ref</kbd>      | 0 or One to one  |
+| <kbd>Ref</kbd>               | <kbd>RefsList</kbd> | 0 or One to many |
+| <kbd>Ref(require=True)</kbd> | <kbd>RefsList</kbd> | One to many      |
+| <kbd>RefsList</kbd>          | <kbd>RefsList</kbd> | Many to many     |
 
 
 ### RefsList
@@ -205,12 +205,12 @@ Relations cardinalities are expressed by the mean of `Ref()` and `RefsList()`:
 
 #### Options
 
-| Option for Ref | Default | Description |
-| - | - | - |
-| <kbd>coll=</kbd> | None | the collection to make the ref |
-| <kbd>field=</kbd> | None | The reverse field in the targeted collection (use [selector](https://github.com/bwallrich/stricto?tab=readme-ov-file#selectors) to target it) |
-| <kbd>ods=</kbd> | ```DeleteStrategy.MUST_BE_EMPTY``` | *On Delete Strategy* see [ods](#deletion-strategies-ods)|
-| <kbd>ofs=</kbd> | ```FillStrategy.FILL``` | *On Fill Strategy* |
+| Option for Ref    | Default                            | Description                                                                                                                                   |
+| ----------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| <kbd>coll=</kbd>  | None                               | the collection to make the ref                                                                                                                |
+| <kbd>field=</kbd> | None                               | The reverse field in the targeted collection (use [selector](https://github.com/bwallrich/stricto?tab=readme-ov-file#selectors) to target it) |
+| <kbd>ods=</kbd>   | ```DeleteStrategy.MUST_BE_EMPTY``` | *On Delete Strategy* see [ods](#deletion-strategies-ods)                                                                                      |
+| <kbd>ofs=</kbd>   | ```FillStrategy.FILL```            | *On Fill Strategy*                                                                                                                            |
 
 And all options availables in [stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string) fields.
 
@@ -261,9 +261,9 @@ a_book = Item({
 backo can manage files in a simple way : Like other [stricto types](https://github.com/bwallrich/stricto?tab=readme-ov-file#basic-types).
 You can use File() or BlobFile().
 
-| object | Description |
-| -- | -- |
-| File() | Generic object to manage a file. You need to define a FileConnector to indicate the object File where to store the file |
+| object     | Description                                                                                                                  |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| File()     | Generic object to manage a file. You need to define a FileConnector to indicate the object File where to store the file      |
 | BlobFile() | File data is integrated literally into the datastructure, so there is no need for a FileConnector. Reserved for small files. |
 
 You can use all [parameters](https://github.com/bwallrich/stricto?tab=readme-ov-file#types) for Files like other fields. 
@@ -271,12 +271,12 @@ You can use all [parameters](https://github.com/bwallrich/stricto?tab=readme-ov-
 
 However there are extra specific parameters :
 
-| Option | Default | Description |
-| - | - | - |
-| ```mime_types=[ str ]``` | None | The list of allowed content types |
-| ```max_size=8192``` | None | The maximum size of the file |
-| ```work_connector=FileConnector``` | None | File working copy connector (main file location) |
-| ```storage_connector=FileConnector``` | None | Second fileConnector used to store the file permanently after processing. If unset, file unique location is *work_connector* |
+| Option                                | Default | Description                                                                                                                  |
+| ------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| ```mime_types=[ str ]```              | None    | The list of allowed content types                                                                                            |
+| ```max_size=8192```                   | None    | The maximum size of the file                                                                                                 |
+| ```work_connector=FileConnector```    | None    | File working copy connector (main file location)                                                                             |
+| ```storage_connector=FileConnector``` | None    | Second fileConnector used to store the file permanently after processing. If unset, file unique location is *work_connector* |
 
 
 Attributes and methods of the File object:
@@ -416,11 +416,11 @@ def your_function_name(right_name: str, o: Item) -> bool:
 
 ```
 
-| right | description |
-| -- | -- |
-| can_read | Check if the collection can be read |
-| can_modify | Check if some elements in the collection can be modified |
-| can_delete | Check if some elements in the collection can be deleted |
+| right      | description                                              |
+| ---------- | -------------------------------------------------------- |
+| can_read   | Check if the collection can be read                      |
+| can_modify | Check if some elements in the collection can be modified |
+| can_delete | Check if some elements in the collection can be deleted  |
 
 
 
@@ -492,10 +492,10 @@ def your_function_name(right_name: str, o: Item) -> bool:
 
 ```
 
-| right | description |
-| -- | -- |
-| can_execute | Check if [current_user](#current_user) can execute the action |
-| can_see|exists | Check if this action is a available for this item |
+| right       | description                                                   |
+| ----------- | ------------------------------------------------------------- |
+| can_execute | Check if [current_user](#current_user) can execute the action |
+| can_see     | exists                                                        | Check if this action is a available for this item |
 
 
 ### routes
@@ -557,9 +557,9 @@ def your_function_name(right_name: str, o: Item) -> bool:
 
 ```
 
-| right | description |
-| -- | -- |
-| can_read | Check if [current_user](#current_user) can do the selection |
+| right    | description                                                 |
+| -------- | ----------------------------------------------------------- |
+| can_read | Check if [current_user](#current_user) can do the selection |
 
 
 ### routes
@@ -699,13 +699,13 @@ However, using jwt is a goot solution. See [Authentication](#authentication) for
 
 `current_user` is a very simple [Stricto Dict](https://github.com/bwallrich/stricto?tab=readme-ov-file#dict) (but can be [extended](#extend-current_user)). It contains :
 
-| key | type | usage |
-| - | - | - |
-| _id | [Stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string) | the _id of the user. 
-| login | [Stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string) | the login or whatever you store . 
-| roles | [Stricto List( String() )](https://github.com/bwallrich/stricto?tab=readme-ov-file#list) | the list of roles for this users. A *role* is a kid of group the user belongs to | 
-| has_role() | function | return True or false to the role givent in param | 
-| reset() | function | change the current_user object type. See [extend current_user](#extend-current_user) for that| 
+| key        | type                                                                                     | usage                                                                                         |
+| ---------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| _id        | [Stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string)       | the _id of the user.                                                                          |
+| login      | [Stricto String()](https://github.com/bwallrich/stricto?tab=readme-ov-file#string)       | the login or whatever you store .                                                             |
+| roles      | [Stricto List( String() )](https://github.com/bwallrich/stricto?tab=readme-ov-file#list) | the list of roles for this users. A *role* is a kid of group the user belongs to              |
+| has_role() | function                                                                                 | return True or false to the role givent in param                                              |
+| reset()    | function                                                                                 | change the current_user object type. See [extend current_user](#extend-current_user) for that |
 
 
 ### extend current_user
@@ -771,32 +771,32 @@ curl -X GET 'http://localhost/myApp/users/123?_view=otherviewname'
 ```
 Answers can be :
 
-| code | data | Description |
-| - | - | - |
-| 200 | JSON object data | the requested item |
-| 401 | None | you are not authorized to view this item |
-| 404 | None | item not found |
-| 500 | None | server-side error |
+| code | data             | Description                              |
+| ---- | ---------------- | ---------------------------------------- |
+| 200  | JSON object data | the requested item                       |
+| 401  | None             | you are not authorized to view this item |
+| 404  | None             | item not found                           |
+| 500  | None             | server-side error                        |
 
 #### GET \<my-app-name\>/\<collection name\>?\<query_string\>
 
 Get a list of objects matching the query string. The query string can be with this format
 
-| key | value | description |
-| - | - | - |
-| \<field\> | \<value\> | matches items where `<field>` equals `<value>`. Example: `surname=donald` finds all items where surname equals to "donald". |
-| \<field\>.\<operator\> | \<value\> | matches items where `<field>` satisfies `<operator>` with `<value>`. Example: `age.$lt=12` finds items where age is less than 12. |
+| key                    | value     | description                                                                                                                                                                  |
+| ---------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| \<field\>              | \<value\> | matches items where `<field>` equals `<value>`. Example: `surname=donald` finds all items where surname equals to "donald".                                                  |
+| \<field\>.\<operator\> | \<value\> | matches items where `<field>` satisfies `<operator>` with `<value>`. Example: `age.$lt=12` finds items where age is less than 12.                                            |
 | \<field\>.\<subfield\> | \<value\> | Matches items where `<field>` is a nested dictionary containing `<subfield>` equal to `<value>`. Example: `address.number=1` matches items where address.number equals to 1. |
 
 
 [list of available operators](https://github.com/bwallrich/stricto?tab=readme-ov-file#filtering-and-matching)
 
 
-| key | value | default | description |
-| - | - | - | - |
-| \_view | string | "client" | selects the view ([stricto views](https://github.com/bwallrich/stricto?tab=readme-ov-file#views))  |
-| \_page | int | - | sets the desired number of items per page in paginated data presentation |
-| \_skip | int | - | skips the n-first items of the result list in paginated data presentation. |
+| key    | value  | default  | description                                                                                       |
+| ------ | ------ | -------- | ------------------------------------------------------------------------------------------------- |
+| \_view | string | "client" | selects the view ([stricto views](https://github.com/bwallrich/stricto?tab=readme-ov-file#views)) |
+| \_page | int    | -        | sets the desired number of items per page in paginated data presentation                          |
+| \_skip | int    | -        | skips the n-first items of the result list in paginated data presentation.                        |
 
 
 The request returns a HTTP status `200` with that JSON object:
@@ -887,15 +887,15 @@ Please refer to [stricto selectors](https://github.com/bwallrich/stricto#selecto
 
 get must provide a json structure in the body :
 
-| field | type | descrimtion |
-| -- | -- | -- |
-| item | dict | the data to check. It can be partial, see examples belowv |
-| path | string | the field to check in the item. This is a selector. Please refer to [stricto selectors](https://github.com/bwallrich/stricto#selectors) for more details |
+| field | type   | descrimtion                                                                                                                                              |
+| ----- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| item  | dict   | the data to check. It can be partial, see examples belowv                                                                                                |
+| path  | string | the field to check in the item. This is a selector. Please refer to [stricto selectors](https://github.com/bwallrich/stricto#selectors) for more details |
 
 The answer is a status 200 message with a json structure :
 
-| field | type | descrimtion |
-| -- | -- | -- |
+| field | type           | descrimtion                                           |
+| ----- | -------------- | ----------------------------------------------------- |
 | error | string or null | if null ther is no error, otherwise the error message |
 
 
@@ -940,10 +940,10 @@ is used to call an action.
 ### Selections routes
 
 
-| Method | Route | Description |
-| -- | -- | -- |
-| <kbd>GET</kbd> | \<my-app-name\>/\<collection name\>/_selections/\<selection_name\> | do the selection  |
-| <kbd>POST</kbd> | \<my-app-name\>/\<collection name\>/_selections/\<selection_name\> | do the selection with complex filter  |
+| Method          | Route                                                              | Description                          |
+| --------------- | ------------------------------------------------------------------ | ------------------------------------ |
+| <kbd>GET</kbd>  | \<my-app-name\>/\<collection name\>/_selections/\<selection_name\> | do the selection                     |
+| <kbd>POST</kbd> | \<my-app-name\>/\<collection name\>/_selections/\<selection_name\> | do the selection with complex filter |
 
 #### example
 
@@ -965,39 +965,39 @@ Meta route are used to retrieve introspective informations about the application
 
 Return the structure of the application as a JSON with thoses keys :
 
-| key | type | description |
-| - | - | - |
-| name | string | The name of the application |
+| key         | type                              | description                         |
+| ----------- | --------------------------------- | ----------------------------------- |
+| name        | string                            | The name of the application         |
 | collections | array of *collection description* | list of all collections description |
 
 ##### collection description
 
 Describe a collection
 
-| key | type | description |
-| - | - | - |
-| name | string | The name ov the collection |
-| item | [meta element description](#meta-element-description) | description of an item |
+| key  | type                                                  | description                |
+| ---- | ----------------------------------------------------- | -------------------------- |
+| name | string                                                | The name ov the collection |
+| item | [meta element description](#meta-element-description) | description of an item     |
 
 ##### meta element description
 
 Describe an element (an item, a key in an item)
 
-| key | type | description |
-| - | - | - |
-| type | string | the type of this element. For example *"<class 'backo.item.Item'>"* or *"<class 'stricto.string.String'>"* |
-| type_short | string | the type of this element, but a short version like *"Item"* or *"String"*|
-| description | string | a sort of comment. (optional) or null |
-| require | boolean | mean this element is required or not |
-| in | array of values | if the element must be in a list of value, or null if not. |
-| constraints | boolean | means if there is one or more constraints on this value |
-| default | -- | the default value for this field (= null if no default value) |
-| transform | boolean | say there is a transformation function |
-| exists | boolean | false mean this field does not exist and must not be displayed |
-| rights | [meta rights description](#meta-rights-description) | the description of rights |
-| sub_scheme | [meta element description](#meta-element-description) | reccusive description for childs if this object is a [Dict](https://github.com/bwallrich/stricto?tab=readme-ov-file#dict) or an Item |
-| sub_type | [meta element description](#meta-element-description) | description of the content if this object is a [List](https://github.com/bwallrich/stricto?tab=readme-ov-file#list) |
-| sub_types | array of [meta element description](#meta-element-description) | description of the tuple content if this object is a [Tuple](https://github.com/bwallrich/stricto?tab=readme-ov-file#tuple) |
+| key         | type                                                           | description                                                                                                                          |
+| ----------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| type        | string                                                         | the type of this element. For example *"<class 'backo.item.Item'>"* or *"<class 'stricto.string.String'>"*                           |
+| type_short  | string                                                         | the type of this element, but a short version like *"Item"* or *"String"*                                                            |
+| description | string                                                         | a sort of comment. (optional) or null                                                                                                |
+| require     | boolean                                                        | mean this element is required or not                                                                                                 |
+| in          | array of values                                                | if the element must be in a list of value, or null if not.                                                                           |
+| constraints | boolean                                                        | means if there is one or more constraints on this value                                                                              |
+| default     | --                                                             | the default value for this field (= null if no default value)                                                                        |
+| transform   | boolean                                                        | say there is a transformation function                                                                                               |
+| exists      | boolean                                                        | false mean this field does not exist and must not be displayed                                                                       |
+| rights      | [meta rights description](#meta-rights-description)            | the description of rights                                                                                                            |
+| sub_scheme  | [meta element description](#meta-element-description)          | reccusive description for childs if this object is a [Dict](https://github.com/bwallrich/stricto?tab=readme-ov-file#dict) or an Item |
+| sub_type    | [meta element description](#meta-element-description)          | description of the content if this object is a [List](https://github.com/bwallrich/stricto?tab=readme-ov-file#list)                  |
+| sub_types   | array of [meta element description](#meta-element-description) | description of the tuple content if this object is a [Tuple](https://github.com/bwallrich/stricto?tab=readme-ov-file#tuple)          |
 
 ##### meta rights description
 
@@ -1225,6 +1225,20 @@ curl -X POST 'http://localhost/myApp/users/_meta' -d { 'name' : "John" }
 
 ```
 
+### OpenAPI route
+This route is used to generate the OpenAPI specification of the backoffice.
+
+For a local usage, you can take at look at [documento](https://github.com/backo-stricto/documento) to quickly serve the documentation using either Swagger, ReDoc, Rapidoc or ST
+calar.
+
+#### GET /\<my-app-name\>/openapi
+
+Return the OpenAPI specification in JSON format.
+
+```bash
+curl -x GET http://localhost/myApp/openapi
+```
+
 ## Internal usage
 Typical use cases for users and related addresses.
 
@@ -1274,11 +1288,11 @@ Each Item has a specific workflow and triggers specific events.
 
 The defined states for each item are following:
 
-| State | descripion |
-| - | - |
-| UNSET | The Item result of a ```.new()``` function. It can't be saved in this state |
-| UNSAVED | The Item has been modified and must be saved |
-| SAVED | The Item is saved in the DB and has not been changed since last save |
+| State   | descripion                                                                  |
+| ------- | --------------------------------------------------------------------------- |
+| UNSET   | The Item result of a ```.new()``` function. It can't be saved in this state |
+| UNSAVED | The Item has been modified and must be saved                                |
+| SAVED   | The Item is saved in the DB and has not been changed since last save        |
 
 
 
@@ -1299,12 +1313,12 @@ stateDiagram
 ### Events
 The following events are triggered when the functions above are called:
 
-| function | event before | event after |
-| - | - | - |
-| .load() |  | "loaded" |
-| .save() |"before_save" | "saved" |
-| .delete() | "before_delete" |  |
-| .create() | None | "created" |
+| function  | event before    | event after |
+| --------- | --------------- | ----------- |
+| .load()   |                 | "loaded"    |
+| .save()   | "before_save"   | "saved"     |
+| .delete() | "before_delete" |             |
+| .create() | None            | "created"   |
 
 #### Example
 Below is a simple use case on how to use these events:
@@ -1405,16 +1419,16 @@ DEBUG-custom- "/my_path/myfile.py", line 196 : this is a debug message with stac
 
 Currently available loggers are :
 
-| logger | description |
-| - | - |
-| backoffice | The main Backoffice system |
-| Item | The database itself (CRUD operations ) |
-| ref | Ref and RefsList objects |
-| transaction | transactions and roolback |
-| yml | yaml database connector |
-| mongo | mongo database connector |
-| select | selections |
-| migration | see [migration](#migration) |
+| logger      | description                            |
+| ----------- | -------------------------------------- |
+| backoffice  | The main Backoffice system             |
+| Item        | The database itself (CRUD operations ) |
+| ref         | Ref and RefsList objects               |
+| transaction | transactions and roolback              |
+| yml         | yaml database connector                |
+| mongo       | mongo database connector               |
+| select      | selections                             |
+| migration   | see [migration](#migration)            |
 
 
 

--- a/backo/backoffice.py
+++ b/backo/backoffice.py
@@ -4,6 +4,7 @@ The Backoffice module
 
 # pylint: disable=logging-fstring-interpolation
 
+from importlib.util import spec_from_file_location
 import json
 import sys
 from typing import Callable
@@ -208,6 +209,11 @@ class Backoffice:  # pylint: disable=too-many-instance-attributes
         )
         flask_app.view_functions[f"_meta_{self.name}"] = self._meta_http
 
+        flask_app.add_url_rule(
+            f"{my_path}/openapi", f"_openapi_{self.name}", methods=["GET"]
+        )
+        flask_app.view_functions[f"_openapi_{self.name}"] = self._export_openapi
+
     def get_meta(self):
         """
         Get all meta information for all collections, view, actions
@@ -226,6 +232,37 @@ class Backoffice:  # pylint: disable=too-many-instance-attributes
         """GET meta information :func:`get_meta` via https"""
         log.debug(f"get meta information for {self.name}")
         return (json.dumps(self.get_meta()), 200)
+
+    def get_openapi(self) -> dict:
+        """
+        Get the OpenAPI specification for this backoffice
+
+        :meta private:
+        """
+
+        return {
+            "openapi": "3.1.0",
+            "info": {
+                "title": f"{self.name}",
+                "description": f"{self.name} backoffice powered by Backo",
+            },
+            "paths": {
+                path: spec
+                for collection in self.collections.values()
+                for path, spec in collection.get_openapi_routes().items()
+            },
+            "components": {
+                "schemas": {
+                    schema: spec
+                    for collection in self.collections.values()
+                    for schema, spec in collection.get_openapi_schemas().items()
+                }
+            },
+        }
+
+    @error_to_http_handler
+    def _export_openapi(self):
+        return (json.dumps(self.get_openapi()), 200)
 
     def check_syntax(self) -> None:
         """

--- a/backo/backoffice.py
+++ b/backo/backoffice.py
@@ -4,10 +4,10 @@ The Backoffice module
 
 # pylint: disable=logging-fstring-interpolation
 
-from importlib.util import spec_from_file_location
+from backo.openapi import JSON_PATCH_SCHEMA
 import json
 import sys
-from typing import Callable
+from typing import Callable, Any
 from flask import Flask
 
 # used for developpement
@@ -240,7 +240,7 @@ class Backoffice:  # pylint: disable=too-many-instance-attributes
         :meta private:
         """
 
-        return {
+        spec: dict[str, Any] = {
             "openapi": "3.1.0",
             "info": {
                 "title": f"{self.name}",
@@ -259,6 +259,8 @@ class Backoffice:  # pylint: disable=too-many-instance-attributes
                 }
             },
         }
+        spec["components"]["schemas"]["json-patch"] = JSON_PATCH_SCHEMA
+        return spec
 
     @error_to_http_handler
     def _export_openapi(self):

--- a/backo/backoffice.py
+++ b/backo/backoffice.py
@@ -266,7 +266,11 @@ class Backoffice:  # pylint: disable=too-many-instance-attributes
 
     @error_to_http_handler
     def _export_openapi(self):
-        return (json.dumps(self.get_openapi()), 200)
+        return (
+            json.dumps(self.get_openapi()),
+            200,
+            {"Content-Type": "application/json"},
+        )
 
     def check_syntax(self) -> None:
         """

--- a/backo/backoffice.py
+++ b/backo/backoffice.py
@@ -10,8 +10,6 @@ from typing import Any, Callable
 
 from flask import Flask
 
-from backo.openapi import BACKO_META_SCHEMA, JSON_PATCH_SCHEMA
-
 # used for developpement
 sys.path.insert(1, "../../stricto")
 
@@ -21,6 +19,7 @@ from .collection import Collection
 from .item import Item
 from .log import LogLevel, log_system
 from .migration_report import MigrationReport
+from .openapi import BACKO_META_SCHEMA, JSON_PATCH_SCHEMA
 from .request_decorators import error_to_http_handler
 from .transaction import OperatorType, Transaction
 

--- a/backo/backoffice.py
+++ b/backo/backoffice.py
@@ -19,7 +19,7 @@ from .collection import Collection
 from .item import Item
 from .log import LogLevel, log_system
 from .migration_report import MigrationReport
-from .openapi import BACKO_META_SCHEMA, JSON_PATCH_SCHEMA
+from .openapi import BACKO_FILTER_SCHEMA, BACKO_META_SCHEMA, JSON_PATCH_SCHEMA
 from .request_decorators import error_to_http_handler
 from .transaction import OperatorType, Transaction
 
@@ -261,6 +261,7 @@ class Backoffice:  # pylint: disable=too-many-instance-attributes
         }
         spec["components"]["schemas"]["json-patch"] = JSON_PATCH_SCHEMA
         spec["components"]["schemas"]["backo-meta"] = BACKO_META_SCHEMA
+        spec["components"]["schemas"]["backo-filter"] = BACKO_FILTER_SCHEMA
         return spec
 
     @error_to_http_handler

--- a/backo/backoffice.py
+++ b/backo/backoffice.py
@@ -10,7 +10,7 @@ from typing import Any, Callable
 
 from flask import Flask
 
-from backo.openapi import JSON_PATCH_SCHEMA
+from backo.openapi import BACKO_META_SCHEMA, JSON_PATCH_SCHEMA
 
 # used for developpement
 sys.path.insert(1, "../../stricto")
@@ -261,6 +261,7 @@ class Backoffice:  # pylint: disable=too-many-instance-attributes
             },
         }
         spec["components"]["schemas"]["json-patch"] = JSON_PATCH_SCHEMA
+        spec["components"]["schemas"]["backo-meta"] = BACKO_META_SCHEMA
         return spec
 
     @error_to_http_handler

--- a/backo/backoffice.py
+++ b/backo/backoffice.py
@@ -4,24 +4,25 @@ The Backoffice module
 
 # pylint: disable=logging-fstring-interpolation
 
-from backo.openapi import JSON_PATCH_SCHEMA
 import json
 import sys
-from typing import Callable, Any
+from typing import Any, Callable
+
 from flask import Flask
+
+from backo.openapi import JSON_PATCH_SCHEMA
 
 # used for developpement
 sys.path.insert(1, "../../stricto")
 
-from stricto import SSyntaxError, validation_parameters, Kparse
+from stricto import Kparse, SSyntaxError, validation_parameters
 
-from .item import Item
-from .request_decorators import error_to_http_handler
-from .transaction import Transaction, OperatorType
 from .collection import Collection
+from .item import Item
+from .log import LogLevel, log_system
 from .migration_report import MigrationReport
-from .log import log_system, LogLevel
-
+from .request_decorators import error_to_http_handler
+from .transaction import OperatorType, Transaction
 
 log = log_system.get_or_create_logger("backoffice", LogLevel.INFO)
 

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -486,6 +486,12 @@ class Collection:
             log.info(f"Add route GET {self.name}/")
             collection_blueprint.add_url_rule("", "select", methods=["GET"])
             collection_blueprint.view_functions[f"{self.name}.select"] = self.filtering
+            self._openapi.add_get_all(
+                self.name,
+                f"/{self.name}",
+                (200, "Successful response."),
+                [(400, "Bad Request"), (500, "Something went wrong.")],
+            )
 
         # POST / Create data
         if self._permissions.is_strictly_allowed_to("create") is not False:

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -691,6 +691,17 @@ class Collection:
             collection_blueprint.view_functions[f"{self.name}.do_post_selection"] = (
                 self.do_post_selection
             )
+            self._openapi.add_selections(
+                f"/{self.name}/_selections",
+                self.name,
+                self._selections,
+                (200, "Selection properly executed"),
+                [
+                    (400, "Bad request"),
+                    (404, "Not found"),
+                    (500, "Something went wrong"),
+                ],
+            )
 
         return collection_blueprint
 

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -533,7 +533,17 @@ class Collection:
                 methods=["POST"],
             )
             collection_blueprint.view_functions[f"{self.name}.meta"] = self.http_meta
-            # TODO openapi
+            self._openapi.add_meta_item(
+                f"/{self.name}/_meta",
+                self.name,
+                self.model.get_schema(),
+                (200, "Meta result"),
+                [
+                    (400, "Bad request"),
+                    (404, "Not found"),
+                    (500, "Something went wrong"),
+                ],
+            )
 
         if self._permissions.is_strictly_allowed_to("read") is not False:
             # GET /<_id>

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -3,48 +3,48 @@ The Collection module
 """
 
 # pylint: disable=logging-fstring-interpolation, too-many-public-methods
-from backo.openapi import OpenAPISpec
+import copy
 import json
+import pprint
 import re
 import sys
-import copy
-import pprint
-from typing import Self, Callable
-from deepdiff import DeepDiff
+from typing import Callable, Self
 
-from flask import request, Blueprint
+from deepdiff import DeepDiff
+from flask import Blueprint, request
+
+from backo.openapi import OpenAPISpec
 
 # used for developpement
 sys.path.insert(1, "../../stricto")
 
 from stricto import (
-    Permissions,
-    StrictoEncoder,
-    FreeDict,
     Dict,
-    String,
-    STypeError,
+    FreeDict,
+    Kparse,
+    Permissions,
     SAttributeError,
-    SSyntaxError,
     SConstraintError,
     SError,
     SRightError,
-    Kparse,
+    SSyntaxError,
+    StrictoEncoder,
+    String,
+    STypeError,
     validation_parameters,
 )
 
-
-from .item import Item
 from .action import Action
-from .selection import Selection
+from .api_toolbox import append_path_to_filter, multidict_to_filter, request_to_object
 from .db_connector import DBConnector
 from .error import PathNotFoundError
-from .log import log_system, LogLevel
-from .request_decorators import error_to_http_handler, check_content_type
-from .api_toolbox import multidict_to_filter, append_path_to_filter, request_to_object
-from .patch import Patch
-from .migration_report import MigrationReport
 from .file.file import File
+from .item import Item
+from .log import LogLevel, log_system
+from .migration_report import MigrationReport
+from .patch import Patch
+from .request_decorators import check_content_type, error_to_http_handler
+from .selection import Selection
 
 log = log_system.get_or_create_logger("collection", LogLevel.INFO)
 log_migration = log_system.get_or_create_logger("migration")

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -487,10 +487,10 @@ class Collection:
             collection_blueprint.add_url_rule("", "select", methods=["GET"])
             collection_blueprint.view_functions[f"{self.name}.select"] = self.filtering
             self._openapi.add_get_all(
-                self.name,
                 f"/{self.name}",
-                (200, "Successful response."),
-                [(400, "Bad Request"), (500, "Something went wrong.")],
+                self.name,
+                (200, "Successful response"),
+                [(400, "Bad Request"), (500, "Something went wrong")],
             )
 
         # POST / Create data
@@ -499,6 +499,13 @@ class Collection:
             collection_blueprint.add_url_rule("", "create", methods=["POST"])
             collection_blueprint.view_functions[f"{self.name}.create"] = (
                 self.http_create
+            )
+            self._openapi.add_post_item(
+                f"/{self.name}",
+                self.name,
+                self.model.get_schema(),
+                (201, "Item created"),
+                [(400, "Bad request"), (500, "Something went wrong")],
             )
 
         # CHECK / Check values

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -2,7 +2,7 @@
 The Collection module
 """
 
-# pylint: disable=logging-fstring-interpolation, too-many-public-methods
+# pylint: disable=logging-fstring-interpolation, too-many-public-methods, too-many-lines, too-many-statements, wrong-import-order
 import copy
 import json
 import pprint
@@ -195,9 +195,15 @@ class Collection:
         }
 
     def get_openapi_routes(self) -> dict:
+        """
+        Return the paths section of the OpenAPI specification.
+        """
         return self._openapi.get_routes()
 
     def get_openapi_schemas(self) -> dict:
+        """
+        Return the schemas section of the OpenAPI specification.
+        """
         return self._openapi.get_schemas()
 
     def set(self, datas: dict | list) -> Item | list:

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -526,7 +526,7 @@ class Collection:
 
         # META /> Check values
         if self._permissions.is_strictly_allowed_to("modify") is not False:
-            log.info(f"Add route GET {self.name}/_meta")
+            log.info(f"Add route POST {self.name}/_meta")
             collection_blueprint.add_url_rule(
                 "/_meta",
                 "meta",
@@ -648,6 +648,18 @@ class Collection:
                 methods=["POST"],
             )
             collection_blueprint.view_functions[f"{self.name}.go"] = self._action_go
+
+            self._openapi.add_actions(
+                f"/{self.name}/_actions",
+                self.name,
+                self._actions,
+                (200, "Action properly executed"),
+                [
+                    (400, "Bad request"),
+                    (404, "Not found"),
+                    (500, "Something went wrong"),
+                ],
+            )
 
         # Selections
         if self._permissions.is_strictly_allowed_to("read") is not False:

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -3,6 +3,7 @@ The Collection module
 """
 
 # pylint: disable=logging-fstring-interpolation, too-many-public-methods
+from backo.openapi import OpenAPISpec
 import json
 import re
 import sys
@@ -166,6 +167,10 @@ class Collection:
         can_read = self._permissions.get("read", True)
         self.register_selection("_all", Selection(None, can_read=can_read))
 
+        # Setup the OpenAPI builder
+        self._openapi = OpenAPISpec()
+        self._openapi.add_schema(self.name, self.model.get_schema())
+
     def get_meta(self) -> dict:
         """Return the meta data for this collection and actions"""
 
@@ -181,14 +186,19 @@ class Collection:
             m["name"] = sel_name
             selections.append(m)
 
-        d = {
+        return {
             "name": self.name,
             "item": self.model.get_schema(),
             "rights": self._permissions.get_as_dict_of_strings(),
             "actions": actions,
             "selections": selections,
         }
-        return d
+
+    def get_openapi_routes(self) -> dict:
+        return self._openapi.get_routes()
+
+    def get_openapi_schemas(self) -> dict:
+        return self._openapi.get_schemas()
 
     def set(self, datas: dict | list) -> Item | list:
         """Set an object or a list of object

--- a/backo/collection.py
+++ b/backo/collection.py
@@ -517,6 +517,12 @@ class Collection:
                 methods=["POST"],
             )
             collection_blueprint.view_functions[f"{self.name}.check"] = self.http_check
+            self._openapi.add_check_item(
+                f"/{self.name}/_check",
+                self.name,
+                self.model.get_schema(),
+                (200, "Check result"),
+            )
 
         # META /> Check values
         if self._permissions.is_strictly_allowed_to("modify") is not False:
@@ -527,6 +533,7 @@ class Collection:
                 methods=["POST"],
             )
             collection_blueprint.view_functions[f"{self.name}.meta"] = self.http_meta
+            # TODO openapi
 
         if self._permissions.is_strictly_allowed_to("read") is not False:
             # GET /<_id>
@@ -553,6 +560,18 @@ class Collection:
                 self.http_get_path_by_id
             )
 
+            self._openapi.add_get_item(
+                f"/{self.name}/{{id}}",
+                self.name,
+                self.model.get_schema(),
+                (200, "Item returned"),
+                [
+                    (400, "Bad request"),
+                    (404, "Not found"),
+                    (500, "Something went wrong"),
+                ],
+            )
+
         # PUT /<_id> Modify Data
         if self._permissions.is_strictly_allowed_to("modify") is not False:
             log.info(f"Add route PUT {self.name}/<string:_id>")
@@ -562,6 +581,17 @@ class Collection:
                 methods=["PUT"],
             )
             collection_blueprint.view_functions[f"{self.name}.put"] = self.http_modify
+            self._openapi.add_put_item(
+                f"/{self.name}/{{id}}",
+                self.name,
+                self.model.get_schema(),
+                (200, "Item modified"),
+                [
+                    (400, "Bad request"),
+                    (404, "Not found"),
+                    (500, "Something went wrong"),
+                ],
+            )
 
         # PATCH /<_id> Modify Data
         if self._permissions.is_strictly_allowed_to("modify") is not False:
@@ -574,6 +604,16 @@ class Collection:
             collection_blueprint.view_functions[f"{self.name}.patch_one"] = (
                 self.http_patch_one
             )
+            self._openapi.add_patch_item(
+                f"/{self.name}/{{id}}",
+                self.name,
+                (200, "Item modified"),
+                [
+                    (400, "Bad request"),
+                    (404, "Not found"),
+                    (500, "Something went wrong"),
+                ],
+            )
 
         # DELETE /<_id> Delete Data
         if self._permissions.is_strictly_allowed_to("delete") is not False:
@@ -585,6 +625,16 @@ class Collection:
             )
             collection_blueprint.view_functions[f"{self.name}.delete"] = (
                 self.http_delete
+            )
+            self._openapi.add_del_item(
+                f"/{self.name}/{{id}}",
+                self.name,
+                (200, "Item modified"),
+                [
+                    (400, "Bad request"),
+                    (404, "Not found"),
+                    (500, "Something went wrong"),
+                ],
             )
 
         # Actions

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -2,10 +2,9 @@
 Utility class to convert backo Collection to OpenAPI specification.
 """
 
-from backo.action import Action
-
 from typing import Any
 
+from backo.action import Action
 
 JSON_PATCH_SCHEMA: dict[str, Any] = {
     "type": "array",

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -82,7 +82,75 @@ def _convert_type(types: list[str]) -> str:
         return "date-time"
     elif "Dict" in types:
         return "object"
-    raise ValueError(f"Could not convert {types} to OpenAPI type.")
+    return "string"  # default to string
+
+
+def _extract_requestbody_content(sub_scheme: dict[str, Any]):
+    required: list[str] = []
+    file_required: list[str] = []
+    properties: dict[str, Any] = {}
+    file_properties: dict[str, Any] = {}
+    base_properties: dict[str, Any] = {}
+    for prop_name, scheme in sub_scheme.items():
+        if prop_name == "_id":
+            continue
+
+        if scheme["rights"]["modify"] is not None and not scheme["rights"]["modify"]:
+            continue
+
+        if scheme["required"]:
+            required.append(prop_name)
+
+        property = {}
+        property["title"] = prop_name
+
+        property["type"] = _convert_type(scheme["types"])
+        if property["type"] == "file":
+            property["type"] = "string"
+            property["contentEncoding"] = "base64"
+            if scheme["required"]:
+                file_required.append(prop_name)
+
+            file_properties[prop_name] = {
+                "title": prop_name,
+                "type": "string",
+                "format": "binary",
+            }
+        elif property["type"] == "date-time":
+            property["type"] = "string"
+            property["format"] = "date-time"
+        else:
+            base_properties[prop_name] = property
+
+        if prop_name != "_meta":
+            properties[prop_name] = property
+
+    multipart_properties: dict[str, Any] = {
+        "_json": {
+            "type": "object",
+            "required": required,
+            "properties": base_properties,
+        },
+    }
+    multipart_properties |= file_properties
+
+    return {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "required": required,
+                "properties": properties,
+            }
+        },
+        "multipart/form-data": {
+            "schema": {
+                "type": "object",
+                "required": ["_json"] + file_required,
+                "properties": multipart_properties,
+            },
+            "encoding": {"_json": {"contentType": "application/json"}},
+        },
+    }
 
 
 class OpenAPISpec:
@@ -516,71 +584,3 @@ class OpenAPISpec:
 
     def get_schemas(self) -> dict:
         return self.__schemas
-
-
-def _extract_requestbody_content(sub_scheme: dict[str, Any]):
-    required: list[str] = []
-    file_required: list[str] = []
-    properties: dict[str, Any] = {}
-    file_properties: dict[str, Any] = {}
-    base_properties: dict[str, Any] = {}
-    for prop_name, scheme in sub_scheme.items():
-        if prop_name == "_id":
-            continue
-
-        if scheme["rights"]["modify"] is not None and not scheme["rights"]["modify"]:
-            continue
-
-        if scheme["required"]:
-            required.append(prop_name)
-
-        property = {}
-        property["title"] = prop_name
-
-        property["type"] = _convert_type(scheme["types"])
-        if property["type"] == "file":
-            property["type"] = "string"
-            property["contentEncoding"] = "base64"
-            if scheme["required"]:
-                file_required.append(prop_name)
-
-            file_properties[prop_name] = {
-                "title": prop_name,
-                "type": "string",
-                "format": "binary",
-            }
-        elif property["type"] == "date-time":
-            property["type"] = "string"
-            property["format"] = "date-time"
-        else:
-            base_properties[prop_name] = property
-
-        if prop_name != "_meta":
-            properties[prop_name] = property
-
-    multipart_properties: dict[str, Any] = {
-        "_json": {
-            "type": "object",
-            "required": required,
-            "properties": base_properties,
-        },
-    }
-    multipart_properties |= file_properties
-
-    return {
-        "application/json": {
-            "schema": {
-                "type": "object",
-                "required": required,
-                "properties": properties,
-            }
-        },
-        "multipart/form-data": {
-            "schema": {
-                "type": "object",
-                "required": ["_json"] + file_required,
-                "properties": multipart_properties,
-            },
-            "encoding": {"_json": {"contentType": "application/json"}},
-        },
-    }

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -4,7 +4,8 @@ Utility class to convert backo Collection to OpenAPI specification.
 
 from typing import Any
 
-from backo.action import Action
+from .action import Action
+from .selection import Selection
 
 JSON_PATCH_SCHEMA: dict[str, Any] = {
     "type": "array",
@@ -89,23 +90,24 @@ def _convert_type(types: list[str]) -> str:
     """
     Convert stricto type to Openapi type
     """
+    openapi_type = "string"  # default type is string if not found
     if "String" in types:
-        return "string"
+        openapi_type = "string"
     elif "Int" in types:
-        return "integer"
+        openapi_type = "integer"
     elif "Float" in types:
-        return "number"
+        openapi_type = "number"
     elif "Bool" in types:
-        return "boolean"
+        openapi_type = "boolean"
     elif "List" in types:
-        return "array"
+        openapi_type = "array"
     elif "File" in types:
-        return "file"
+        openapi_type = "file"
     elif "Datetime" in types:
-        return "date-time"
+        openapi_type = "date-time"
     elif "Dict" in types:
-        return "object"
-    return "string"  # default to string
+        openapi_type = "object"
+    return openapi_type
 
 
 def _extract_requestbody_content(sub_scheme: dict[str, Any]):
@@ -328,12 +330,17 @@ class OpenAPISpec:
         spec["operationId"] = f"meta_{item_name}"
         spec["requestBody"] = {
             "content": {
-                "application/json": {
-                    # the required are not really required here, can't use the schema
-                    "schema": {"$ref": f"#/components/schemas/{item_name}"}
-                }
+                "application/json": {"schema": {"type": "object", "properties": {}}}
             }
         }
+
+        for prop_name, prop_scheme in item_schema["sub_scheme"].items():
+            spec["requestBody"]["content"]["application/json"]["schema"]["properties"][
+                prop_name
+            ] = {
+                "type": _convert_type(prop_scheme["types"]),
+                "description": prop_scheme["description"],
+            }
 
         spec["responses"] = {}
         spec["responses"][str(ok[0])] = {
@@ -643,6 +650,70 @@ class OpenAPISpec:
                 }
 
             self.__add_spec(base_route + f"/{name}/{{id}}", "post", spec)
+
+    def add_selections(
+        self,
+        base_route: str,
+        item_name: str,
+        selections: dict[str, Selection],
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ):
+        """
+        Set OpenAPI specification for POST /items/_selections/<string:selection>/<string:id>
+        """
+        for name, selection in selections.items():
+            spec: dict[str, Any] = {}
+            spec["summary"] = f"Selection {name} on {item_name}"
+            spec["description"] = (
+                f"Get items defined by selection {name} from {item_name} collection, with eventual filtering."
+            )
+            spec["operationId"] = f"selection_get_{name}_{item_name}"
+            spec["parameters"] = [
+                {
+                    "name": "qstring",
+                    "in": "query",
+                    "required": False,
+                    "schema": {"type": "string"},
+                    "description": "Query string",
+                }
+            ]
+            spec["responses"] = {}
+            spec["responses"][str(ok[0])] = {
+                "description": ok[1],
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "result": {
+                                    "type": "array",
+                                    "items": {
+                                        "$ref": f"#/components/schemas/{item_name}"
+                                    },
+                                },
+                                "total": {"type": "integer"},
+                                "_skip": {"type": "integer"},
+                                "_page": {"type": "integer"},
+                            },
+                        }
+                    }
+                },
+            }
+
+            for error_code, error_msg in errors:
+                spec["responses"][str(error_code)] = {
+                    "description": error_msg,
+                    "content": {"text/plain": {}},
+                }
+
+            self.__add_spec(base_route + f"/{name}", "get", spec)
+
+            spec = dict(spec)
+            spec["operationId"] = f"selection_post_{name}_{item_name}"
+            spec["requestBody"] = {"content": {}}
+
+            self.__add_spec(base_route + f"/{name}", "post", spec)
 
     def __add_spec(self, route: str, method: str, spec: dict) -> None:
         if route not in self.__routes:

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -100,13 +100,13 @@ def _extract_requestbody_content(sub_scheme: dict[str, Any]):
         if scheme["required"]:
             required.append(prop_name)
 
-        property = {}
-        property["title"] = prop_name
+        prop = {}
+        prop["title"] = prop_name
 
-        property["type"] = _convert_type(scheme["types"])
-        if property["type"] == "file":
-            property["type"] = "string"
-            property["contentEncoding"] = "base64"
+        prop["type"] = _convert_type(scheme["types"])
+        if prop["type"] == "file":
+            prop["type"] = "string"
+            prop["contentEncoding"] = "base64"
             if scheme["required"]:
                 file_required.append(prop_name)
 
@@ -115,14 +115,14 @@ def _extract_requestbody_content(sub_scheme: dict[str, Any]):
                 "type": "string",
                 "format": "binary",
             }
-        elif property["type"] == "date-time":
-            property["type"] = "string"
-            property["format"] = "date-time"
+        elif prop["type"] == "date-time":
+            prop["type"] = "string"
+            prop["format"] = "date-time"
         else:
-            base_properties[prop_name] = property
+            base_properties[prop_name] = prop
 
         if prop_name != "_meta":
-            properties[prop_name] = property
+            properties[prop_name] = prop
 
     multipart_properties: dict[str, Any] = {
         "_json": {
@@ -153,6 +153,10 @@ def _extract_requestbody_content(sub_scheme: dict[str, Any]):
 
 
 class OpenAPISpec:
+    """
+    Utility function to generate the OpenAPI specification of a backoffice
+    """
+
     def __init__(self):
         self.__routes: dict[str, dict] = {}
         self.__schemas: dict[str, dict] = {}
@@ -164,6 +168,9 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ) -> None:
+        """
+        Set OpenAPI specification for GET /items
+        """
         spec: dict[str, Any] = {}
         spec["summary"] = (
             f"List all existing item in {item_name} collection, with eventual filtering."
@@ -215,6 +222,9 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ) -> None:
+        """
+        Set OpenAPI specification for POST /items
+        """
         spec: dict[str, Any] = {}
         spec["summary"] = f"Add an item in {item_name} collection."
         spec["operationId"] = f"add_{item_name}"
@@ -248,6 +258,9 @@ class OpenAPISpec:
         item_schema: dict[str, Any],
         code: tuple[int, str],
     ) -> None:
+        """
+        Set OpenAPI specification for POST /items/_check
+        """
         spec: dict[str, Any] = {}
         spec["summary"] = f"Check if item can be put in {item_name} collection."
         spec["operationId"] = f"check_{item_name}"
@@ -279,6 +292,9 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ):
+        """
+        Set OpenAPI specification for GET /items/<string:id>
+        """
         spec: dict[str, Any] = {}
         spec["summary"] = (
             f"Get the item identified by {{id}} in {item_name} collection."
@@ -367,6 +383,9 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ):
+        """
+        Set OpenAPI specification for PUT /items/<string:id>
+        """
         spec: dict[str, Any] = {}
         spec["summary"] = (
             f"Modify the item identified by {{id}} in {item_name} collection."
@@ -411,6 +430,9 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ):
+        """
+        Set OpenAPI specification for DEL /items/<string:id>
+        """
         spec: dict[str, Any] = {}
         spec["summary"] = (
             f"Delete the item identified by {{id}} in {item_name} collection."
@@ -448,6 +470,9 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ):
+        """
+        Set OpenAPI specification for PATCH /items/<string:id>
+        """
         spec: dict[str, Any] = {}
         spec["summary"] = (
             f"Patch the item identified by {{id}} in {item_name} collection."
@@ -506,6 +531,9 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ):
+        """
+        Set OpenAPI specification for POST /items/_actions/<string:action>/<string:id>
+        """
         for name, action in actions.items():
             print(f"REGISTER {name}")
             spec: dict[str, Any] = {}
@@ -550,29 +578,35 @@ class OpenAPISpec:
         self.__routes[route][method] = spec
 
     def get_routes(self) -> dict:
+        """
+        Return OpenAPI paths dictionary
+        """
         return self.__routes
 
     def add_schema(self, name: str, item_schema: dict) -> None:
+        """
+        Add OpenAPI schemas
+        """
         required: list[str] = []
         properties: dict[str, Any] = {}
         for prop_name, scheme in item_schema["sub_scheme"].items():
-            property = {"title": prop_name}
+            prop = {"title": prop_name}
             if scheme["required"]:
                 required.append(prop_name)
 
-            property["type"] = _convert_type(scheme["types"])
+            prop["type"] = _convert_type(scheme["types"])
             # missing "items" . "type" for array
-            if property["type"] == "object":
+            if prop["type"] == "object":
                 self.add_schema(f"{name}_{prop_name}", scheme)
-                property["$ref"] = f"#/components/schemas/{name}_{prop_name}"
-            elif property["type"] == "file":
-                property["type"] = "string"
-                property["contentEncoding"] = "base64"
-            elif property["type"] == "date-time":
-                property["type"] = "string"
-                property["format"] = "date-time"
+                prop["$ref"] = f"#/components/schemas/{name}_{prop_name}"
+            elif prop["type"] == "file":
+                prop["type"] = "string"
+                prop["contentEncoding"] = "base64"
+            elif prop["type"] == "date-time":
+                prop["type"] = "string"
+                prop["format"] = "date-time"
 
-            properties[prop_name] = property
+            properties[prop_name] = prop
 
         self.__schemas[name] = {
             "title": name,
@@ -582,4 +616,7 @@ class OpenAPISpec:
         }
 
     def get_schemas(self) -> dict:
+        """
+        Return OpenAPI schemas dictionary
+        """
         return self.__schemas

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -5,22 +5,25 @@ Utility class to convert backo Collection to OpenAPI specification.
 from typing import Any
 
 
+# TODO refactor this ugly implementation
 def _convert_type(types: list[str]) -> str:
     """
     Convert stricto type to Openapi type
     """
     if "String" in types:
         return "string"
-    elif "Integer" in types:
+    elif "Int" in types:
         return "integer"
     elif "Float" in types:
         return "number"
     elif "Bool" in types:
         return "boolean"
-    elif "Dict" in types:
-        return "object"
     elif "List" in types:
         return "array"
+    elif "File" in types:
+        return "file"
+    elif "Dict" in types:
+        return "object"
     raise ValueError(f"Could not convert {types} to OpenAPI type.")
 
 
@@ -31,8 +34,8 @@ class OpenAPISpec:
 
     def add_get_all(
         self,
-        item_name: str,
         route: str,
+        item_name: str,
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ) -> None:
@@ -82,8 +85,94 @@ class OpenAPISpec:
 
         self.__routes[route]["get"] = spec
 
-    def add_post_item(self) -> None:
-        pass
+    def add_post_item(
+        self,
+        route: str,
+        item_name: str,
+        item_schema: dict,
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ) -> None:
+        if route not in self.__routes:
+            self.__routes[route] = {}
+
+        spec: dict[str, Any] = {}
+        spec["summary"] = f"Add an item in {item_name} collection."
+        spec["operationId"] = f"add_{item_name}"
+
+        required: list[str] = []
+        properties: dict[str, Any] = {}
+        file_properties: dict[str, Any] = {}
+        base_properties: dict[str, Any] = {}
+        for prop_name, scheme in item_schema["sub_scheme"].items():
+            if prop_name == "_id":
+                continue
+
+            if scheme["required"]:
+                required.append(prop_name)
+
+            property = {}
+            property["title"] = prop_name
+
+            property["type"] = _convert_type(scheme["types"])
+            if property["type"] == "file":
+                property["type"] = "string"
+                property["contentEncoding"] = "base64"
+
+                file_properties[prop_name] = {
+                    "title": prop_name,
+                    "type": "string",
+                    "format": "binary",
+                }
+            else:
+                base_properties[prop_name] = property
+            properties[prop_name] = property
+
+        multipart_properties: dict[str, Any] = {
+            "_json": {
+                "type": "object",
+                "required": required,
+                "properties": base_properties,
+            },
+        }
+        multipart_properties |= file_properties
+
+        spec["requestBody"] = {"content": {}}
+        spec["requestBody"]["content"] = {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": required,
+                    "properties": properties,
+                }
+            },
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "required": ["_json"],  # TODO required files ?
+                    "properties": multipart_properties,
+                },
+                "encoding": {"_json": {"contentType": "application/json"}},
+            },
+        }
+
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": f"#/components/schemas/{item_name}"}
+                }
+            },
+        }
+
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__routes[route]["post"] = spec
 
     def get_routes(self) -> dict:
         return self.__routes
@@ -97,10 +186,13 @@ class OpenAPISpec:
                 required.append(prop_name)
 
             property["type"] = _convert_type(scheme["types"])
-
+            # missing "items" . "type" for array
             if property["type"] == "object":
                 self.add_schema(f"{name}_{prop_name}", scheme)
                 property["$ref"] = f"#/components/schemas/{name}_{prop_name}"
+            elif property["type"] == "file":
+                property["type"] = "string"
+                property["contentEncoding"] = "base64"
 
             properties[prop_name] = property
 

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -284,6 +284,43 @@ class OpenAPISpec:
 
         self.__add_spec(route, "post", spec)
 
+    def add_meta_item(
+        self,
+        route: str,
+        item_name: str,
+        item_schema: dict[str, Any],
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ):
+        """
+        Set OpenAPI specification for POST /items/_meta
+        """
+        spec: dict[str, Any] = {}
+        spec["summary"] = f"Modify the metadata of {item_name} collection."
+        spec["operationId"] = f"meta_{item_name}"
+        spec["requestBody"] = {
+            "content": _extract_requestbody_content(
+                item_schema["sub_scheme"]["_meta"]["sub_scheme"]
+            )
+        }
+
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": f"#/components/schemas/{item_name}__meta"}
+                }
+            },
+        }
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__add_spec(route, "post", spec)
+
     def add_get_item(
         self,
         route: str,

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -172,7 +172,8 @@ class OpenAPISpec:
         Set OpenAPI specification for GET /items
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = (
+        spec["summary"] = f"List {item_name}"
+        spec["description"] = (
             f"List all existing item in {item_name} collection, with eventual filtering."
         )
         spec["operationId"] = f"list_{item_name}"
@@ -226,7 +227,8 @@ class OpenAPISpec:
         Set OpenAPI specification for POST /items
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = f"Add an item in {item_name} collection."
+        spec["summary"] = f"Create {item_name}"
+        spec["description"] = f"Add an item in {item_name} collection."
         spec["operationId"] = f"add_{item_name}"
 
         spec["requestBody"] = {
@@ -262,7 +264,8 @@ class OpenAPISpec:
         Set OpenAPI specification for POST /items/_check
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = f"Check if item can be put in {item_name} collection."
+        spec["summary"] = f"Check {item_name}"
+        spec["description"] = f"Check if item can be put in {item_name} collection."
         spec["operationId"] = f"check_{item_name}"
 
         spec["requestBody"] = {
@@ -296,7 +299,8 @@ class OpenAPISpec:
         Set OpenAPI specification for POST /items/_meta
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = f"Modify the metadata of {item_name} collection."
+        spec["summary"] = f"Update {item_name} metadata"
+        spec["description"] = f"Modify the metadata of {item_name} collection."
         spec["operationId"] = f"meta_{item_name}"
         spec["requestBody"] = {
             "content": _extract_requestbody_content(
@@ -333,7 +337,8 @@ class OpenAPISpec:
         Set OpenAPI specification for GET /items/<string:id>
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = (
+        spec["summary"] = f"Get {item_name}"
+        spec["description"] = (
             f"Get the item identified by {{id}} in {item_name} collection."
         )
         spec["operationId"] = f"get_{item_name}"
@@ -372,7 +377,8 @@ class OpenAPISpec:
         self.__add_spec(route, "get", spec)
 
         spec: dict[str, Any] = {}
-        spec["summary"] = (
+        spec["summary"] = f"Get {item_name} file"
+        spec["description"] = (
             f"Get the file {{path}} of item identified by {{id}} in {item_name} collection."
         )
         spec["operationId"] = f"get_{item_name}_path"
@@ -424,7 +430,8 @@ class OpenAPISpec:
         Set OpenAPI specification for PUT /items/<string:id>
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = (
+        spec["summary"] = f"Update {item_name}"
+        spec["description"] = (
             f"Modify the item identified by {{id}} in {item_name} collection."
         )
         spec["operationId"] = f"put_{item_name}"
@@ -471,7 +478,8 @@ class OpenAPISpec:
         Set OpenAPI specification for DEL /items/<string:id>
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = (
+        spec["summary"] = f"Delete {item_name}"
+        spec["description"] = (
             f"Delete the item identified by {{id}} in {item_name} collection."
         )
         spec["operationId"] = f"del_{item_name}"
@@ -511,7 +519,8 @@ class OpenAPISpec:
         Set OpenAPI specification for PATCH /items/<string:id>
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = (
+        spec["summary"] = f"Patch {item_name}"
+        spec["description"] = (
             f"Patch the item identified by {{id}} in {item_name} collection."
         )
         spec["operationId"] = f"patch_{item_name}"
@@ -572,9 +581,9 @@ class OpenAPISpec:
         Set OpenAPI specification for POST /items/_actions/<string:action>/<string:id>
         """
         for name, action in actions.items():
-            print(f"REGISTER {name}")
             spec: dict[str, Any] = {}
-            spec["summary"] = (
+            spec["summary"] = f"Trigger {name} on {item_name}"
+            spec["description"] = (
                 f"Trigger the action {name} on item identified by {{id}} in {item_name} collection."
             )
             spec["operationId"] = f"action_{name}_on_{item_name}"

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -61,6 +61,30 @@ JSON_PATCH_SCHEMA: dict[str, Any] = {
 }
 
 
+BACKO_META_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "types": {"type": "array", "items": {"type": "string"}},
+        "type_short": {"type": "string"},
+        "description": {"type": "string"},
+        "required": {"type": "boolean"},
+        "in": {"type": "string"},
+        "contraints": {"type": "array", "items": {"type": "string"}},
+        "default": {"type": "string"},
+        "transform": {"type": "string"},
+        "exists": {"type": "boolean"},
+        "rights": {
+            "type": "object",
+            "properties": {
+                "read": {"type": "boolean"},
+                "modify": {"type": "boolean"},
+            },
+        },
+        "sub_scheme": {"type": "object"},
+    },
+}
+
+
 def _convert_type(types: list[str]) -> str:
     """
     Convert stricto type to Openapi type
@@ -299,13 +323,16 @@ class OpenAPISpec:
         Set OpenAPI specification for POST /items/_meta
         """
         spec: dict[str, Any] = {}
-        spec["summary"] = f"Update {item_name} metadata"
-        spec["description"] = f"Modify the metadata of {item_name} collection."
+        spec["summary"] = f"Get {item_name} metadata"
+        spec["description"] = f"Inspect the metadata of {item_name} collection."
         spec["operationId"] = f"meta_{item_name}"
         spec["requestBody"] = {
-            "content": _extract_requestbody_content(
-                item_schema["sub_scheme"]["_meta"]["sub_scheme"]
-            )
+            "content": {
+                "application/json": {
+                    # the required are not really required here, can't use the schema
+                    "schema": {"$ref": f"#/components/schemas/{item_name}"}
+                }
+            }
         }
 
         spec["responses"] = {}
@@ -313,7 +340,7 @@ class OpenAPISpec:
             "description": ok[1],
             "content": {
                 "application/json": {
-                    "schema": {"$ref": f"#/components/schemas/{item_name}__meta"}
+                    "schema": {"$ref": "#/components/schemas/backo-meta"}
                 }
             },
         }

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -1,0 +1,115 @@
+"""
+Utility class to convert backo Collection to OpenAPI specification.
+"""
+
+from typing import Any
+
+
+def _convert_type(types: list[str]) -> str:
+    """
+    Convert stricto type to Openapi type
+    """
+    if "String" in types:
+        return "string"
+    elif "Integer" in types:
+        return "integer"
+    elif "Float" in types:
+        return "number"
+    elif "Bool" in types:
+        return "boolean"
+    elif "Dict" in types:
+        return "object"
+    elif "List" in types:
+        return "array"
+    raise ValueError(f"Could not convert {types} to OpenAPI type.")
+
+
+class OpenAPISpec:
+    def __init__(self):
+        self.__routes: dict[str, dict] = {}
+        self.__schemas: dict[str, dict] = {}
+
+    def add_get_all(
+        self,
+        item_name: str,
+        route: str,
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ) -> None:
+        if route not in self.__routes:
+            self.__routes[route] = {}
+
+        spec: dict[str, Any] = {}
+        spec["summary"] = (
+            f"List all existing item in {item_name} collection, with eventual filtering."
+        )
+        spec["operationId"] = f"list_{item_name}"
+        spec["parameters"] = [
+            {
+                "name": "qstring",
+                "in": "query",
+                "required": False,
+                "schema": {"type": "string"},
+                "description": "Query string",
+            }
+        ]
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "result": {
+                                "type": "array",
+                                "items": {"$ref": f"#/components/schemas/{item_name}"},
+                            },
+                            "total": {"type": "integer"},
+                            "_skip": {"type": "integer"},
+                            "_page": {"type": "integer"},
+                        },
+                    }
+                }
+            },
+        }
+
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__routes[route]["get"] = spec
+
+    def add_post_item(self) -> None:
+        pass
+
+    def get_routes(self) -> dict:
+        return self.__routes
+
+    def add_schema(self, name: str, item_schema: dict) -> None:
+        required: list[str] = []
+        properties: dict[str, Any] = {}
+        for prop_name, scheme in item_schema["sub_scheme"].items():
+            property = {"title": prop_name}
+            if scheme["required"]:
+                required.append(prop_name)
+
+            property["type"] = _convert_type(scheme["types"])
+
+            if property["type"] == "object":
+                self.add_schema(f"{name}_{prop_name}", scheme)
+                property["$ref"] = f"#/components/schemas/{name}_{prop_name}"
+
+            properties[prop_name] = property
+
+        self.__schemas[name] = {
+            "title": name,
+            "type": "object",
+            "required": required,
+            "properties": properties,
+        }
+
+    def get_schemas(self) -> dict:
+        return self.__schemas

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -5,7 +5,61 @@ Utility class to convert backo Collection to OpenAPI specification.
 from typing import Any
 
 
-# TODO refactor this ugly implementation
+JSON_PATCH_SCHEMA: dict[str, Any] = {
+    "type": "array",
+    "items": {
+        "oneOf": [
+            {
+                "additionalProperties": False,
+                "required": ["value", "op", "path"],
+                "properties": {
+                    "path": {
+                        "description": "A JSON Pointer path.",
+                        "type": "string",
+                    },
+                    "op": {
+                        "description": "The operation to perform.",
+                        "type": "string",
+                        "enum": ["add", "replace", "test"],
+                    },
+                    "value": {"description": "The value to add, replace or test."},
+                },
+            },
+            {
+                "additionalProperties": False,
+                "required": ["op", "path"],
+                "properties": {
+                    "path": {
+                        "description": "A JSON Pointer path.",
+                        "type": "string",
+                    },
+                    "op": {
+                        "description": "The operation to perform.",
+                        "type": "string",
+                        "enum": ["remove"],
+                    },
+                },
+            },
+            {
+                "additionalProperties": False,
+                "required": ["from", "op", "path"],
+                "properties": {
+                    "path": {
+                        "description": "A JSON Pointer path.",
+                        "type": "string",
+                    },
+                    "op": {
+                        "description": "The operation to perform.",
+                        "type": "string",
+                        "enum": ["move", "copy"],
+                    },
+                },
+            },
+        ]
+    },
+}
+
+
 def _convert_type(types: list[str]) -> str:
     """
     Convert stricto type to Openapi type
@@ -22,6 +76,8 @@ def _convert_type(types: list[str]) -> str:
         return "array"
     elif "File" in types:
         return "file"
+    elif "Datetime" in types:
+        return "date-time"
     elif "Dict" in types:
         return "object"
     raise ValueError(f"Could not convert {types} to OpenAPI type.")
@@ -39,9 +95,6 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ) -> None:
-        if route not in self.__routes:
-            self.__routes[route] = {}
-
         spec: dict[str, Any] = {}
         spec["summary"] = (
             f"List all existing item in {item_name} collection, with eventual filtering."
@@ -83,7 +136,7 @@ class OpenAPISpec:
                 "content": {"text/plain": {}},
             }
 
-        self.__routes[route]["get"] = spec
+        self.__add_spec(route, "get", spec)
 
     def add_post_item(
         self,
@@ -93,14 +146,12 @@ class OpenAPISpec:
         ok: tuple[int, str],
         errors: list[tuple[int, str]],
     ) -> None:
-        if route not in self.__routes:
-            self.__routes[route] = {}
-
         spec: dict[str, Any] = {}
         spec["summary"] = f"Add an item in {item_name} collection."
         spec["operationId"] = f"add_{item_name}"
 
         required: list[str] = []
+        file_required: list[str] = []
         properties: dict[str, Any] = {}
         file_properties: dict[str, Any] = {}
         base_properties: dict[str, Any] = {}
@@ -118,15 +169,22 @@ class OpenAPISpec:
             if property["type"] == "file":
                 property["type"] = "string"
                 property["contentEncoding"] = "base64"
+                if scheme["required"]:
+                    file_required.append(prop_name)
 
                 file_properties[prop_name] = {
                     "title": prop_name,
                     "type": "string",
                     "format": "binary",
                 }
+            elif property["type"] == "date-time":
+                property["type"] = "string"
+                property["format"] = "date-time"
             else:
                 base_properties[prop_name] = property
-            properties[prop_name] = property
+
+            if prop_name != "_meta":
+                properties[prop_name] = property
 
         multipart_properties: dict[str, Any] = {
             "_json": {
@@ -149,7 +207,7 @@ class OpenAPISpec:
             "multipart/form-data": {
                 "schema": {
                     "type": "object",
-                    "required": ["_json"],  # TODO required files ?
+                    "required": ["_json"] + file_required,
                     "properties": multipart_properties,
                 },
                 "encoding": {"_json": {"contentType": "application/json"}},
@@ -172,7 +230,396 @@ class OpenAPISpec:
                 "content": {"text/plain": {}},
             }
 
-        self.__routes[route]["post"] = spec
+        self.__add_spec(route, "post", spec)
+
+    def add_check_item(
+        self,
+        route: str,
+        item_name: str,
+        item_schema: dict[str, Any],
+        code: tuple[int, str],
+    ) -> None:
+        spec: dict[str, Any] = {}
+        spec["summary"] = f"Check if item can be put in {item_name} collection."
+        spec["operationId"] = f"check_{item_name}"
+
+        required: list[str] = []
+        file_required: list[str] = []
+        properties: dict[str, Any] = {}
+        file_properties: dict[str, Any] = {}
+        base_properties: dict[str, Any] = {}
+        for prop_name, scheme in item_schema["sub_scheme"].items():
+            if prop_name == "_id":
+                continue
+
+            if scheme["required"]:
+                required.append(prop_name)
+
+            property = {}
+            property["title"] = prop_name
+
+            property["type"] = _convert_type(scheme["types"])
+            if property["type"] == "file":
+                property["type"] = "string"
+                property["contentEncoding"] = "base64"
+                if scheme["required"]:
+                    file_required.append(prop_name)
+
+                file_properties[prop_name] = {
+                    "title": prop_name,
+                    "type": "string",
+                    "format": "binary",
+                }
+            elif property["type"] == "date-time":
+                property["type"] = "string"
+                property["format"] = "date-time"
+            else:
+                base_properties[prop_name] = property
+
+            if prop_name != "_meta":
+                properties[prop_name] = property
+
+        multipart_properties: dict[str, Any] = {
+            "_json": {
+                "type": "object",
+                "required": required,
+                "properties": base_properties,
+            },
+        }
+        multipart_properties |= file_properties
+
+        spec["requestBody"] = {"content": {}}
+        spec["requestBody"]["content"] = {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": required,
+                    "properties": properties,
+                }
+            },
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "required": ["_json"] + file_required,
+                    "properties": multipart_properties,
+                },
+                "encoding": {"_json": {"contentType": "application/json"}},
+            },
+        }
+
+        spec["responses"] = {}
+        spec["responses"][str(code[0])] = {
+            "description": code[1],
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"error": {"type": "string"}},
+                    }
+                }
+            },
+        }
+
+        self.__add_spec(route, "post", spec)
+
+    def add_get_item(
+        self,
+        route: str,
+        item_name: str,
+        item_schema: dict[str, Any],
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ):
+        spec: dict[str, Any] = {}
+        spec["summary"] = (
+            f"Get the item identified by {{id}} in {item_name} collection."
+        )
+        spec["operationId"] = f"get_{item_name}"
+        spec["parameters"] = [
+            {
+                "name": "id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string"},
+                "description": "Id of the item to retrieve",
+            },
+            {
+                "name": "qstring",
+                "in": "query",
+                "required": False,
+                "schema": {"type": "string"},
+                "description": "Query string",
+            },
+        ]
+
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": f"#/components/schemas/{item_name}"}
+                }
+            },
+        }
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__add_spec(route, "get", spec)
+
+        spec: dict[str, Any] = {}
+        spec["summary"] = (
+            f"Get the file {{path}} of item identified by {{id}} in {item_name} collection."
+        )
+        spec["operationId"] = f"get_{item_name}_path"
+
+        files: list[str] = []
+        for prop_name, prop_scheme in item_schema["sub_scheme"].items():
+            if "File" in prop_scheme["types"]:
+                files.append(prop_name)
+
+        spec["parameters"] = [
+            {
+                "name": "id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string"},
+                "description": "Id of the item",
+            },
+            {
+                "name": "path",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string", "enum": files},
+                "description": "File of the item to retrieve",
+            },
+        ]
+
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {"application/octet-stream": {}},
+        }
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__add_spec(route + "/{path}", "get", spec)
+
+    def add_put_item(
+        self,
+        route: str,
+        item_name: str,
+        item_schema: dict[str, Any],
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ):
+        spec: dict[str, Any] = {}
+        spec["summary"] = (
+            f"Modify the item identified by {{id}} in {item_name} collection."
+        )
+        spec["operationId"] = f"put_{item_name}"
+        spec["parameters"] = [
+            {
+                "name": "id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string"},
+                "description": "Id of the item to modify",
+            },
+        ]
+
+        required: list[str] = []
+        file_required: list[str] = []
+        properties: dict[str, Any] = {}
+        file_properties: dict[str, Any] = {}
+        base_properties: dict[str, Any] = {}
+        for prop_name, scheme in item_schema["sub_scheme"].items():
+            if prop_name == "_id":
+                continue
+
+            if (
+                scheme["rights"]["modify"] is not None
+                and not scheme["rights"]["modify"]
+            ):
+                continue
+
+            if scheme["required"]:
+                required.append(prop_name)
+
+            property = {}
+            property["title"] = prop_name
+
+            property["type"] = _convert_type(scheme["types"])
+            if property["type"] == "file":
+                property["type"] = "string"
+                property["contentEncoding"] = "base64"
+                if scheme["required"]:
+                    file_required.append(prop_name)
+
+                file_properties[prop_name] = {
+                    "title": prop_name,
+                    "type": "string",
+                    "format": "binary",
+                }
+            elif property["type"] == "date-time":
+                property["type"] = "string"
+                property["format"] = "date-time"
+            else:
+                base_properties[prop_name] = property
+
+            if prop_name != "_meta":
+                properties[prop_name] = property
+
+        multipart_properties: dict[str, Any] = {
+            "_json": {
+                "type": "object",
+                "required": required,
+                "properties": base_properties,
+            },
+        }
+        multipart_properties |= file_properties
+
+        spec["requestBody"] = {"content": {}}
+        spec["requestBody"]["content"] = {
+            "application/json": {
+                "schema": {
+                    "type": "object",
+                    "required": required,
+                    "properties": properties,
+                }
+            },
+            "multipart/form-data": {
+                "schema": {
+                    "type": "object",
+                    "required": ["_json"] + file_required,
+                    "properties": multipart_properties,
+                },
+                "encoding": {"_json": {"contentType": "application/json"}},
+            },
+        }
+
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": f"#/components/schemas/{item_name}"}
+                }
+            },
+        }
+
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__add_spec(route, "put", spec)
+
+    def add_del_item(
+        self,
+        route: str,
+        item_name: str,
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ):
+        spec: dict[str, Any] = {}
+        spec["summary"] = (
+            f"Delete the item identified by {{id}} in {item_name} collection."
+        )
+        spec["operationId"] = f"del_{item_name}"
+
+        spec["parameters"] = [
+            {
+                "name": "id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string"},
+                "description": "Id of the item to delete",
+            },
+        ]
+
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {"text/plain": {}},
+        }
+
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__add_spec(f"/{route}/{{id}}", "del", spec)
+
+    def add_patch_item(
+        self,
+        route: str,
+        item_name: str,
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ):
+        spec: dict[str, Any] = {}
+        spec["summary"] = (
+            f"Patch the item identified by {{id}} in {item_name} collection."
+        )
+        spec["operationId"] = f"patch_{item_name}"
+        spec["parameters"] = [
+            {
+                "name": "id",
+                "in": "path",
+                "required": True,
+                "schema": {"type": "string"},
+                "description": "Id of the item to delete",
+            },
+        ]
+
+        spec["requestBody"] = {
+            "content": {},
+            "description": "A json-patch object or an array of json-patch item for this item",
+        }
+        spec["requestBody"]["content"] = {
+            "application/json": {
+                "schema": {
+                    "oneOf": [
+                        {"$ref": "#/components/schemas/json-patch"},
+                        {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/json-patch"},
+                        },
+                    ]
+                }
+            }
+        }
+        spec["responses"] = {}
+        spec["responses"][str(ok[0])] = {
+            "description": ok[1],
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": f"#/components/schemas/{item_name}"}
+                }
+            },
+        }
+
+        for error_code, error_msg in errors:
+            spec["responses"][str(error_code)] = {
+                "description": error_msg,
+                "content": {"text/plain": {}},
+            }
+
+        self.__add_spec(route, "patch", spec)
+
+    def __add_spec(self, route: str, method: str, spec: dict) -> None:
+        if route not in self.__routes:
+            self.__routes[route] = {}
+
+        self.__routes[route][method] = spec
 
     def get_routes(self) -> dict:
         return self.__routes
@@ -193,6 +640,9 @@ class OpenAPISpec:
             elif property["type"] == "file":
                 property["type"] = "string"
                 property["contentEncoding"] = "base64"
+            elif property["type"] == "date-time":
+                property["type"] = "string"
+                property["format"] = "date-time"
 
             properties[prop_name] = property
 

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -8,6 +8,8 @@ from .action import Action
 from .selection import Selection
 
 JSON_PATCH_SCHEMA: dict[str, Any] = {
+    "title": "json-patch",
+    "description": "A JSON Patch document as defined in RFC 6902.",
     "type": "array",
     "items": {
         "oneOf": [
@@ -63,6 +65,8 @@ JSON_PATCH_SCHEMA: dict[str, Any] = {
 
 
 BACKO_META_SCHEMA: dict[str, Any] = {
+    "title": "backo-meta",
+    "description": "Metadata of a Backo collection.",
     "type": "object",
     "properties": {
         "types": {"type": "array", "items": {"type": "string"}},
@@ -83,6 +87,13 @@ BACKO_META_SCHEMA: dict[str, Any] = {
         },
         "sub_scheme": {"type": "object"},
     },
+}
+
+BACKO_FILTER_SCHEMA: dict[str, Any] = {
+    "title": "backo-filter",
+    "description": "Filter for Backo selection.",
+    "type": "object",
+    "properties": {},  # TODO
 }
 
 
@@ -662,7 +673,7 @@ class OpenAPISpec:
         """
         Set OpenAPI specification for POST /items/_selections/<string:selection>/<string:id>
         """
-        for name, selection in selections.items():
+        for name in selections.keys():
             spec: dict[str, Any] = {}
             spec["summary"] = f"Selection {name} on {item_name}"
             spec["description"] = (
@@ -710,8 +721,15 @@ class OpenAPISpec:
             self.__add_spec(base_route + f"/{name}", "get", spec)
 
             spec = dict(spec)
+            del spec["parameters"]
             spec["operationId"] = f"selection_post_{name}_{item_name}"
-            spec["requestBody"] = {"content": {}}
+            spec["requestBody"] = {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/backo-filter"}
+                    }
+                }
+            }
 
             self.__add_spec(base_route + f"/{name}", "post", spec)
 

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -93,7 +93,7 @@ BACKO_FILTER_SCHEMA: dict[str, Any] = {
     "title": "backo-filter",
     "description": "Filter for Backo selection.",
     "type": "object",
-    "properties": {},  # TODO
+    "properties": {},  # TODO # pylint: disable=fixme
 }
 
 

--- a/backo/openapi.py
+++ b/backo/openapi.py
@@ -2,6 +2,8 @@
 Utility class to convert backo Collection to OpenAPI specification.
 """
 
+from backo.action import Action
+
 from typing import Any
 
 
@@ -150,68 +152,8 @@ class OpenAPISpec:
         spec["summary"] = f"Add an item in {item_name} collection."
         spec["operationId"] = f"add_{item_name}"
 
-        required: list[str] = []
-        file_required: list[str] = []
-        properties: dict[str, Any] = {}
-        file_properties: dict[str, Any] = {}
-        base_properties: dict[str, Any] = {}
-        for prop_name, scheme in item_schema["sub_scheme"].items():
-            if prop_name == "_id":
-                continue
-
-            if scheme["required"]:
-                required.append(prop_name)
-
-            property = {}
-            property["title"] = prop_name
-
-            property["type"] = _convert_type(scheme["types"])
-            if property["type"] == "file":
-                property["type"] = "string"
-                property["contentEncoding"] = "base64"
-                if scheme["required"]:
-                    file_required.append(prop_name)
-
-                file_properties[prop_name] = {
-                    "title": prop_name,
-                    "type": "string",
-                    "format": "binary",
-                }
-            elif property["type"] == "date-time":
-                property["type"] = "string"
-                property["format"] = "date-time"
-            else:
-                base_properties[prop_name] = property
-
-            if prop_name != "_meta":
-                properties[prop_name] = property
-
-        multipart_properties: dict[str, Any] = {
-            "_json": {
-                "type": "object",
-                "required": required,
-                "properties": base_properties,
-            },
-        }
-        multipart_properties |= file_properties
-
-        spec["requestBody"] = {"content": {}}
-        spec["requestBody"]["content"] = {
-            "application/json": {
-                "schema": {
-                    "type": "object",
-                    "required": required,
-                    "properties": properties,
-                }
-            },
-            "multipart/form-data": {
-                "schema": {
-                    "type": "object",
-                    "required": ["_json"] + file_required,
-                    "properties": multipart_properties,
-                },
-                "encoding": {"_json": {"contentType": "application/json"}},
-            },
+        spec["requestBody"] = {
+            "content": _extract_requestbody_content(item_schema["sub_scheme"])
         }
 
         spec["responses"] = {}
@@ -243,68 +185,8 @@ class OpenAPISpec:
         spec["summary"] = f"Check if item can be put in {item_name} collection."
         spec["operationId"] = f"check_{item_name}"
 
-        required: list[str] = []
-        file_required: list[str] = []
-        properties: dict[str, Any] = {}
-        file_properties: dict[str, Any] = {}
-        base_properties: dict[str, Any] = {}
-        for prop_name, scheme in item_schema["sub_scheme"].items():
-            if prop_name == "_id":
-                continue
-
-            if scheme["required"]:
-                required.append(prop_name)
-
-            property = {}
-            property["title"] = prop_name
-
-            property["type"] = _convert_type(scheme["types"])
-            if property["type"] == "file":
-                property["type"] = "string"
-                property["contentEncoding"] = "base64"
-                if scheme["required"]:
-                    file_required.append(prop_name)
-
-                file_properties[prop_name] = {
-                    "title": prop_name,
-                    "type": "string",
-                    "format": "binary",
-                }
-            elif property["type"] == "date-time":
-                property["type"] = "string"
-                property["format"] = "date-time"
-            else:
-                base_properties[prop_name] = property
-
-            if prop_name != "_meta":
-                properties[prop_name] = property
-
-        multipart_properties: dict[str, Any] = {
-            "_json": {
-                "type": "object",
-                "required": required,
-                "properties": base_properties,
-            },
-        }
-        multipart_properties |= file_properties
-
-        spec["requestBody"] = {"content": {}}
-        spec["requestBody"]["content"] = {
-            "application/json": {
-                "schema": {
-                    "type": "object",
-                    "required": required,
-                    "properties": properties,
-                }
-            },
-            "multipart/form-data": {
-                "schema": {
-                    "type": "object",
-                    "required": ["_json"] + file_required,
-                    "properties": multipart_properties,
-                },
-                "encoding": {"_json": {"contentType": "application/json"}},
-            },
+        spec["requestBody"] = {
+            "content": _extract_requestbody_content(item_schema["sub_scheme"])
         }
 
         spec["responses"] = {}
@@ -433,74 +315,8 @@ class OpenAPISpec:
             },
         ]
 
-        required: list[str] = []
-        file_required: list[str] = []
-        properties: dict[str, Any] = {}
-        file_properties: dict[str, Any] = {}
-        base_properties: dict[str, Any] = {}
-        for prop_name, scheme in item_schema["sub_scheme"].items():
-            if prop_name == "_id":
-                continue
-
-            if (
-                scheme["rights"]["modify"] is not None
-                and not scheme["rights"]["modify"]
-            ):
-                continue
-
-            if scheme["required"]:
-                required.append(prop_name)
-
-            property = {}
-            property["title"] = prop_name
-
-            property["type"] = _convert_type(scheme["types"])
-            if property["type"] == "file":
-                property["type"] = "string"
-                property["contentEncoding"] = "base64"
-                if scheme["required"]:
-                    file_required.append(prop_name)
-
-                file_properties[prop_name] = {
-                    "title": prop_name,
-                    "type": "string",
-                    "format": "binary",
-                }
-            elif property["type"] == "date-time":
-                property["type"] = "string"
-                property["format"] = "date-time"
-            else:
-                base_properties[prop_name] = property
-
-            if prop_name != "_meta":
-                properties[prop_name] = property
-
-        multipart_properties: dict[str, Any] = {
-            "_json": {
-                "type": "object",
-                "required": required,
-                "properties": base_properties,
-            },
-        }
-        multipart_properties |= file_properties
-
-        spec["requestBody"] = {"content": {}}
-        spec["requestBody"]["content"] = {
-            "application/json": {
-                "schema": {
-                    "type": "object",
-                    "required": required,
-                    "properties": properties,
-                }
-            },
-            "multipart/form-data": {
-                "schema": {
-                    "type": "object",
-                    "required": ["_json"] + file_required,
-                    "properties": multipart_properties,
-                },
-                "encoding": {"_json": {"contentType": "application/json"}},
-            },
+        spec["requestBody"] = {
+            "content": _extract_requestbody_content(item_schema["sub_scheme"])
         }
 
         spec["responses"] = {}
@@ -615,6 +431,51 @@ class OpenAPISpec:
 
         self.__add_spec(route, "patch", spec)
 
+    def add_actions(
+        self,
+        base_route: str,
+        item_name: str,
+        actions: dict[str, Action],
+        ok: tuple[int, str],
+        errors: list[tuple[int, str]],
+    ):
+        for name, action in actions.items():
+            print(f"REGISTER {name}")
+            spec: dict[str, Any] = {}
+            spec["summary"] = (
+                f"Trigger the action {name} on item identified by {{id}} in {item_name} collection."
+            )
+            spec["operationId"] = f"action_{name}_on_{item_name}"
+            spec["parameters"] = [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                    "description": "Id of the item on which trigger the action",
+                },
+            ]
+
+            spec["requestBody"] = {
+                "content": _extract_requestbody_content(
+                    action.get_schema()["sub_scheme"]
+                )
+            }
+
+            spec["responses"] = {}
+            spec["responses"][str(ok[0])] = {
+                "description": ok[1],
+                "content": {},
+            }
+
+            for error_code, error_msg in errors:
+                spec["responses"][str(error_code)] = {
+                    "description": error_msg,
+                    "content": {"text/plain": {}},
+                }
+
+            self.__add_spec(base_route + f"/{name}/{{id}}", "post", spec)
+
     def __add_spec(self, route: str, method: str, spec: dict) -> None:
         if route not in self.__routes:
             self.__routes[route] = {}
@@ -655,3 +516,71 @@ class OpenAPISpec:
 
     def get_schemas(self) -> dict:
         return self.__schemas
+
+
+def _extract_requestbody_content(sub_scheme: dict[str, Any]):
+    required: list[str] = []
+    file_required: list[str] = []
+    properties: dict[str, Any] = {}
+    file_properties: dict[str, Any] = {}
+    base_properties: dict[str, Any] = {}
+    for prop_name, scheme in sub_scheme.items():
+        if prop_name == "_id":
+            continue
+
+        if scheme["rights"]["modify"] is not None and not scheme["rights"]["modify"]:
+            continue
+
+        if scheme["required"]:
+            required.append(prop_name)
+
+        property = {}
+        property["title"] = prop_name
+
+        property["type"] = _convert_type(scheme["types"])
+        if property["type"] == "file":
+            property["type"] = "string"
+            property["contentEncoding"] = "base64"
+            if scheme["required"]:
+                file_required.append(prop_name)
+
+            file_properties[prop_name] = {
+                "title": prop_name,
+                "type": "string",
+                "format": "binary",
+            }
+        elif property["type"] == "date-time":
+            property["type"] = "string"
+            property["format"] = "date-time"
+        else:
+            base_properties[prop_name] = property
+
+        if prop_name != "_meta":
+            properties[prop_name] = property
+
+    multipart_properties: dict[str, Any] = {
+        "_json": {
+            "type": "object",
+            "required": required,
+            "properties": base_properties,
+        },
+    }
+    multipart_properties |= file_properties
+
+    return {
+        "application/json": {
+            "schema": {
+                "type": "object",
+                "required": required,
+                "properties": properties,
+            }
+        },
+        "multipart/form-data": {
+            "schema": {
+                "type": "object",
+                "required": ["_json"] + file_required,
+                "properties": multipart_properties,
+            },
+            "encoding": {"_json": {"contentType": "application/json"}},
+        },
+    }

--- a/backo/ref.py
+++ b/backo/ref.py
@@ -133,14 +133,12 @@ class Ref(String):  # pylint: disable=too-many-instance-attributes
         :return: the schema
         :rtype: dict
         """
-        a = super().self.get_schema()
+        a = super().get_schema()
         a["collection"] = self._collection
         a["reverse"] = self._reverse
         return a
 
-    def check_syntax(
-        self, event_name: str, root, me, **kwargs
-    ):  # pylint: disable=unused-argument
+    def check_syntax(self, event_name: str, root, me, **kwargs):  # pylint: disable=unused-argument
         """
         Check if everything is correct log some warnings
         """
@@ -167,17 +165,13 @@ class Ref(String):  # pylint: disable=too-many-instance-attributes
             reverse_field = other.select(me._reverse)
             # Must check == None rather
 
-            if not isinstance(
-                reverse_field, (refslist.RefsList, Ref)
-            ):  # pylint: disable=singleton-comparison
+            if not isinstance(reverse_field, (refslist.RefsList, Ref)):  # pylint: disable=singleton-comparison
                 log.error(
                     f'{root._collection.name}/{me.path_name()}: Collection "{me._collection}", "{me._reverse}" is not a Ref or a RefsList'
                 )
                 return
 
-    def on_before_save(
-        self, event_name, root, me, **kwargs
-    ):  # pylint: disable=unused-argument
+    def on_before_save(self, event_name, root, me, **kwargs):  # pylint: disable=unused-argument
         """
         Before saving, check if the reference
         as changed from an old value
@@ -233,9 +227,7 @@ class Ref(String):  # pylint: disable=too-many-instance-attributes
         if me.get_value() is not None:
             self.on_created(event_name, root, me, **kwargs)
 
-    def on_created(
-        self, event_name, root, me, **kwargs
-    ):  # pylint: disable=unused-argument
+    def on_created(self, event_name, root, me, **kwargs):  # pylint: disable=unused-argument
         """
         The object as been created
         check for the reverse field and modify it
@@ -298,7 +290,6 @@ class Ref(String):  # pylint: disable=too-many-instance-attributes
         if isinstance(reverse_field, refslist.RefsList):
             if reverse_field._fill_strategy == refslist.FillStrategy.FILL:
                 if root._id.get_value() not in reverse_field.get_value():
-
                     # update the reverse
                     log.debug(f"update reverse refList {me._reverse} with {root._id}")
                     reverse_field.append(root._id)
@@ -311,9 +302,7 @@ class Ref(String):  # pylint: disable=too-many-instance-attributes
             "{0}.{1} is not a Ref or a RefsList", self._collection, me._reverse
         )
 
-    def on_delete(
-        self, event_name, root, me, **kwargs
-    ):  # pylint: disable=unused-argument, too-many-return-statements
+    def on_delete(self, event_name, root, me, **kwargs):  # pylint: disable=unused-argument, too-many-return-statements
         """
         The object will be deleted
         clean structure

--- a/backo/refslist.py
+++ b/backo/refslist.py
@@ -171,14 +171,12 @@ class RefsList(List):
         :return: the schema
         :rtype: dict
         """
-        a = super().self.get_schema()
+        a = super().get_schema()
         a["collection"] = self._collection
         a["reverse"] = self._reverse
         return a
 
-    def check_syntax(
-        self, event_name: str, root, me, **kwargs
-    ):  # pylint: disable=unused-argument
+    def check_syntax(self, event_name: str, root, me, **kwargs):  # pylint: disable=unused-argument
         """
         Check if everything is correct log some warnings
         """
@@ -204,9 +202,7 @@ class RefsList(List):
             other = me._coll_ref.new_item()
             reverse_field = other.select(me._reverse)
 
-            if not isinstance(
-                reverse_field, (ref.Ref, RefsList)
-            ):  # pylint: disable=singleton-comparison
+            if not isinstance(reverse_field, (ref.Ref, RefsList)):  # pylint: disable=singleton-comparison
                 log.error(
                     f'{root._collection.name}/{me.path_name()}: Collection "{me._collection}", "{me._reverse}" is not a Ref or a RefsList'
                 )
@@ -246,9 +242,7 @@ class RefsList(List):
             )
         return self._coll_ref.select(match_filter)
 
-    def on_delete_must_by_empty(
-        self, event_name: str, root: Dict, me: Self, **kwargs
-    ):  # pylint: disable=unused-argument
+    def on_delete_must_by_empty(self, event_name: str, root: Dict, me: Self, **kwargs):  # pylint: disable=unused-argument
         """
         The object will be deleted only if this list is empty
         otherwist error
@@ -297,9 +291,7 @@ class RefsList(List):
                     'Collection (not filled) "{0}" not empty', self._collection
                 )
 
-    def on_delete_with_reverse(
-        self, event_name, root, me, **kwargs
-    ):  # pylint: disable=unused-argument
+    def on_delete_with_reverse(self, event_name, root, me, **kwargs):  # pylint: disable=unused-argument
         """
         The ref object object will be deleted too
         otherwist error
@@ -354,9 +346,7 @@ class RefsList(List):
             for other in other_list:
                 other.delete(**kwargs)
 
-    def on_delete_clean_reverse(
-        self, event_name: str, root: Dict, me: Self, **kwargs
-    ):  # pylint: disable=unused-argument
+    def on_delete_clean_reverse(self, event_name: str, root: Dict, me: Self, **kwargs):  # pylint: disable=unused-argument
         """
         The reflecting object is cleaned too
 
@@ -524,9 +514,7 @@ class RefsList(List):
             if other_modified_flag:
                 other.save(**kwargs)
 
-    def on_created(
-        self, event_name, root, me, **kwargs
-    ):  # pylint: disable=unused-argument
+    def on_created(self, event_name, root, me, **kwargs):  # pylint: disable=unused-argument
         """
         A creation object with a RefList
         Fill other if
@@ -558,9 +546,7 @@ class RefsList(List):
         if me:
             self._change_others_ref_to(root, me, me, root._id, **kwargs)
 
-    def on_modify_clean_reverse(
-        self, event_name, root, me, **kwargs
-    ):  # pylint: disable=unused-argument
+    def on_modify_clean_reverse(self, event_name, root, me, **kwargs):  # pylint: disable=unused-argument
         """
         The reflecting object is set to the new one
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,0 +1,50 @@
+"""
+Test for OpenAPI specification generation.
+"""
+
+import unittest
+from typing import Callable
+
+from flask import Flask
+from flask.testing import FlaskClient
+
+from backo import Backoffice
+
+
+def _build_test_client(backoffice_generator: Callable[[], Backoffice]) -> FlaskClient:
+    """
+    Build a test client for the given backoffice generator.
+
+    :param backoffice_generator: A callable that returns a Backoffice instance.
+    :type backoffice_generator: Callable[[], Backoffice]
+    :return: A Flask test client.
+    :rtype: FlaskClient
+    """
+    app = Flask(__name__)
+    backoffice = backoffice_generator()
+    backoffice.build_routes(app)
+    ctx = app.app_context()
+    ctx.push()
+    return app.test_client()
+
+
+class TestOpenAPI(unittest.TestCase):
+    """
+    Test OpenAPI specification generation.
+    """
+
+    def test_openapi_basic(self):
+        """
+        Test the generation of OpenAPI specification.
+        """
+        client = _build_test_client(lambda: Backoffice("app"))
+        response = client.get("/app/openapi")  # Trigger the OpenAPI generation
+        self.assertEqual(response.status_code, 200)
+        spec = response.get_json()
+        # Expecting OpenAPI version 3.1.0
+        self.assertEqual(spec["openapi"], "3.1.0")
+        # Expecting 3 default schemas: backo-meta, json-patch, backo-filter
+        self.assertEqual(len(spec["components"]["schemas"]), 3)
+        self.assertIn("backo-meta", spec["components"]["schemas"])
+        self.assertIn("json-patch", spec["components"]["schemas"])
+        self.assertIn("backo-filter", spec["components"]["schemas"])

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -48,3 +48,5 @@ class TestOpenAPI(unittest.TestCase):
         self.assertIn("backo-meta", spec["components"]["schemas"])
         self.assertIn("json-patch", spec["components"]["schemas"])
         self.assertIn("backo-filter", spec["components"]["schemas"])
+        # Expecting no routes
+        self.assertEqual(len(spec["paths"]), 0)

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -3,29 +3,10 @@ Test for OpenAPI specification generation.
 """
 
 import unittest
-from typing import Callable
 
 from flask import Flask
-from flask.testing import FlaskClient
 
 from backo import Backoffice
-
-
-def _build_test_client(backoffice_generator: Callable[[], Backoffice]) -> FlaskClient:
-    """
-    Build a test client for the given backoffice generator.
-
-    :param backoffice_generator: A callable that returns a Backoffice instance.
-    :type backoffice_generator: Callable[[], Backoffice]
-    :return: A Flask test client.
-    :rtype: FlaskClient
-    """
-    app = Flask(__name__)
-    backoffice = backoffice_generator()
-    backoffice.build_routes(app)
-    ctx = app.app_context()
-    ctx.push()
-    return app.test_client()
 
 
 class TestOpenAPI(unittest.TestCase):
@@ -33,14 +14,33 @@ class TestOpenAPI(unittest.TestCase):
     Test OpenAPI specification generation.
     """
 
+    def test_openapi_route(self):
+        """
+        Test if the /openapi route is properly registered.
+        """
+        # Setup Test Flask app and Backoffice
+        app = Flask(__name__)
+        backoffice = Backoffice("app")
+        backoffice.build_routes(app)
+        ctx = app.app_context()
+        ctx.push()
+        client = app.test_client()
+        # Test the /openapi route
+        response = client.get("/app/openapi")
+        # Ensure the response is successful and contains JSON data with correct MIME type
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.get_json())
+
     def test_openapi_basic(self):
         """
-        Test the generation of OpenAPI specification.
+        Test the basic OpenAPI specification generation for an empty backoffice.
+        - OpenAPI version 3.1.0
+        - 3 default schemas: backo-meta, json-patch, backo-filter
+        - no routes
         """
-        client = _build_test_client(lambda: Backoffice("app"))
-        response = client.get("/app/openapi")  # Trigger the OpenAPI generation
-        self.assertEqual(response.status_code, 200)
-        spec = response.get_json()
+        # Setup Test Backoffice
+        backoffice = Backoffice("app")
+        spec = backoffice.get_openapi()
         # Expecting OpenAPI version 3.1.0
         self.assertEqual(spec["openapi"], "3.1.0")
         # Expecting 3 default schemas: backo-meta, json-patch, backo-filter


### PR DESCRIPTION
This PR solves #10 by exposing a `/openapi` route exporting the openapi specification in json format.

:warning: it still misses before merging:
- intensive checking to ensure the generated documentation is correct and up-to-date.
- the backo filter schema (`openapi.py` L#96 )