### PR TITLE
9 sqlite dbconnector

### DIFF
--- a/backo/__init__.py
+++ b/backo/__init__.py
@@ -13,6 +13,7 @@ from stricto import *
 from .item import Item
 from .db_yml_connector import DBYmlConnector
 from .db_mongo_connector import DBMongoConnector
+from .db_sql_connector import DBSQLConnector
 from .db_connector import DBConnector
 from .current_user import current_user, CurrentUser, CurrentUserWrapper
 from .error import (

--- a/backo/__init__.py
+++ b/backo/__init__.py
@@ -13,7 +13,7 @@ from stricto import *
 from .item import Item
 from .db_yml_connector import DBYmlConnector
 from .db_mongo_connector import DBMongoConnector
-from .db_sql_connector import DBSQLConnector
+from .db_sqlite_connector import DBSQLiteConnector
 from .db_connector import DBConnector
 from .current_user import current_user, CurrentUser, CurrentUserWrapper
 from .error import (

--- a/backo/__init__.py
+++ b/backo/__init__.py
@@ -46,4 +46,9 @@ from .request_decorators import (
     return_http_error,
     error_to_http_handler,
 )
-from .api_toolbox import multidict_to_filter, append_path_to_filter
+from .api_toolbox import (
+    multidict_to_filter,
+    append_path_to_filter,
+    flatter,
+    unflatter,
+)

--- a/backo/api_toolbox.py
+++ b/backo/api_toolbox.py
@@ -10,6 +10,83 @@ from flask import Request
 from werkzeug.datastructures import ImmutableMultiDict
 
 
+def flatter(out: dict, src: Any, root_path=[]) -> None:
+    """avoid nested dict by combination of key.
+    follow nested dict into list too.
+
+    transform
+
+    { 'location' : {
+        'street' : 'far'
+        }
+    }
+
+    into
+
+    { 'location.street' : 'far' }
+
+
+
+    :param out: the flattened dict
+    :type out: dict
+    :param src: the dict to "flatten"
+    :type src: dict
+    :param root_path: internal, defaults to []
+    :type root_path: list, optional
+    """
+    if isinstance(src, dict):
+        for key, value in src.items():
+            flatter(out, value, root_path + [key])
+        return
+
+    if isinstance(src, list):
+        a = []
+        for value in src:
+            if isinstance(value, dict):
+                o = {}
+                flatter(o, value)
+                a.append(o)
+            else:
+                a.append(value)
+        out[f'{".".join(root_path)}'] = a
+        return
+
+    out[f'{".".join(root_path)}'] = src
+
+
+def unflatter(out: dict, path: list[str], value: Any) -> None:
+    """unflatter dict
+
+    This is the opposite of flatter()
+
+    :param out: the output dict
+    :type out: dict
+    :param path: the key as a path, like [ 'location', 'street' ]
+    :type path: list[str]
+    :param value: any value
+    :type value: Any
+    """
+
+    k = path.pop(0)
+    if len(path) == 0:
+        if isinstance(value, list):
+            a = []
+            for subv in value:
+                if isinstance(subv, dict):
+                    o = {}
+                    for k, v in subv.items():
+                        unflatter(o, k.split("."), v)
+                    a.append(o)
+                else:
+                    a.append(subv)
+            out[k] = a
+        else:
+            out[k] = value
+        return
+    out[k] = {}
+    unflatter(out[k], path, value)
+
+
 def append_path_to_filter(filter_as_dict: dict, key, value: list | tuple):
     """transform a
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -13,7 +13,7 @@ sys.path.insert(1, "../../stricto")
 from stricto import Kparse
 
 from .db_connector import DBConnector
-# from .error import NotFoundError, DBError
+from .error import NotFoundError
 from .error import DBError
 from .log import log_system
 
@@ -80,9 +80,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         str_cols = []
 
-        print(f"TABLE {meta["name"]}")
+        print(f"TABLE {self._collection_name}")
 
-        for col_name, col_data in meta["item"]["sub_scheme"].items():
+        for col_name, col_data in meta["sub_scheme"].items():
             if not col_name.startswith("_"):
                 col_type = col_data["types"][0]
                 str_cols.append(f"{col_name} {self._to_sql_type(col_type)}")
@@ -100,7 +100,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         try:
             self._cursor.execute(str_request)
             self._con.commit()
-            print(self._cursor)
+            self._meta = meta
 
         except sqlite3.OperationalError as e:
             print(f"✗ Operational Error: {e}")
@@ -151,7 +151,13 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             return "TRUE" if val else "FALSE"
         if isinstance(val, str):
             return f"'{val}'"
-        
+
+        return val
+
+    def _map(self, val, target_types):
+        if "Bool" in target_types:
+            return bool(val)
+
         return val
 
     def _is_internal_field(self, field):
@@ -205,6 +211,47 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def get_by_id(self, _id: str) -> dict:
         """See :func:`DBConnector.get_by_id`"""
         log.debug(f"read {_id} ")
+
+        try:
+            # Select by id
+            str_request = f"SELECT * FROM {self._collection_name} WHERE _id='{_id}'"
+            print(str_request)
+            self._cursor.execute(str_request)
+            row = self._cursor.fetchone()
+
+            print(row)
+
+            log.debug(f"✓ GetById {self._collection_name} {_id}")
+
+            o = {"_id": row[0]}
+            for i, (col_name, col_data) in enumerate(self._meta["sub_scheme"].items()):
+                if not col_name.startswith("_"):
+                    o[col_name] = self._map(row[i + 1], col_data["types"])
+
+            if o is None:
+                raise NotFoundError(
+                    '_id "{0}" not found in collection "{1}"',
+                    _id,
+                    self._collection_name,
+                )
+
+            return o
+
+        except sqlite3.OperationalError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Operational Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.IntegrityError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Integrity Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.Error as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Database Error: {e} while "{self._collection_name}.create()"'
+            ) from e
 
     def delete_by_id(self, _id: str) -> bool:
         """See :func:`DBConnector.delete_by_id`"""

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -77,10 +77,12 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             return False
 
         rev_coll = col_data["collection"]
-        rev_col = col_data["reverse"][2:]  # Tricky for now
+        rev_col = col_data["reverse"][
+            2:
+        ]  # Tricky for now need to select actual field $.my.path.to
         return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
 
-    def _many_many_table_data(self, col_name, col_data):
+    def _many_many_table_structure(self, col_name, col_data):
         """
         Generate name for intermediate table of many-many relationship
         """
@@ -88,12 +90,17 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         rev_col_name = col_data["reverse"][2:]  # Tricky for now
         a = f"{self._collection_name}_{col_name}_{rev_coll}"
         b = f"{rev_coll}_{rev_col_name}_{self._collection_name}"
+        table_name = a if a < b else b
+        src_col = rev_col_name if a < b else col_name
+        dst_col = col_name if a < b else rev_col_name
+        src_coll = self._collection_name if a < b else rev_coll
+        dst_coll = rev_coll if a < b else self._collection_name
         return (
-            a if a < b else b,
-            self._collection_name,
-            rev_coll,
-            col_name,
-            rev_col_name,
+            table_name,
+            src_coll,
+            dst_coll,
+            src_col,
+            dst_col,
         )
 
     def create_table(self):
@@ -132,18 +139,19 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         # Generate intermediate tables (many-many relationships)
         for col_name, col_data in self._scheme.items():
             if self._is_many_many_relationship(col_data):
-                table_name, coll0, coll1, col0, col1 = self._many_many_table_data(
-                    col_name, col_data
+                table_name, src_coll, dst_coll, src_col, dst_col = (
+                    self._many_many_table_structure(col_name, col_data)
                 )
                 str_request = f"""
                 CREATE TABLE IF NOT EXISTS {table_name} (
-                    {col0} TEXT ,
-                    {col1} TEXT ,
-                    FOREIGN KEY ({col0}) REFERENCES {coll1}(_id) ,
-                    FOREIGN KEY ({col1}) REFERENCES {coll0}(_id)
+                    {src_col} TEXT ,
+                    {dst_col} TEXT ,
+                    FOREIGN KEY ({src_col}) REFERENCES {src_coll}(_id) ,
+                    FOREIGN KEY ({dst_col}) REFERENCES {dst_coll}(_id) ,
+                    PRIMARY KEY ({src_col}, {dst_col})
                 );
                 """
-                print(str_request)
+                log.debug(f"Execute: {str_request}")
                 self._sqlite_try(create_table_execute)
 
     def drop(self) -> None:
@@ -220,19 +228,33 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
             t = []
             for col_name, col_data in self._scheme.items():
-                col_types = col_data["types"]
-                if "RefsList" not in col_types and col_name != "_meta":
+                # Exclude RefsList and _meta columns for insert
+                if "RefsList" not in col_data["types"] and col_name != "_meta":
                     t.append((col_name, self._format_val(o[col_name])))
 
             str_col_names = ",".join(field_name for field_name, _ in t)
             str_values = ",".join(field_value for _, field_value in t)
 
             str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({str_values})"
-            log.debug(f"Execute: {str_request}")
-            # Insert
-            self._cursor.execute(str_request)
-            self._con.commit()
 
+            # Insert
+            log.debug(f"Execute: {str_request}")
+            self._cursor.execute(str_request)
+            # self._con.commit()
+
+            # Insert many-many relationships in intermediate table
+            for col_name, col_data in self._scheme.items():
+                if self._is_many_many_relationship(col_data):
+                    table_name, _, _, src_col, dst_col = (
+                        self._many_many_table_structure(col_name, col_data)
+                    )
+                    for dst_id in o[col_name]:
+                        str_request = f"INSERT INTO {table_name} ({src_col}, {dst_col}) VALUES ('{_id}', '{dst_id}')"
+                        log.debug(f"Execute: {str_request}")
+                        self._cursor.execute(str_request)
+
+            # Commit all requests
+            self._con.commit()
             log.debug(f"✓ Created {self._collection_name} {_id}")
 
             return _id

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -82,30 +82,93 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         ]  # Tricky for now need to select actual field $.my.path.to
         return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
 
+    # def _many_many_table_structure(self, col_name, col_data):
+    #     """
+    #     Generate name for intermediate table of many-many relationship
+    #     """
+    #     rev_coll = col_data["collection"]
+    #     rev_col_name = col_data["reverse"][2:]  # Tricky for now
+    #     a = f"{self._collection_name}_{col_name}_{rev_coll}"
+    #     b = f"{rev_coll}_{rev_col_name}_{self._collection_name}"
+    #     table_name = a if a < b else b
+    #     src_col = rev_col_name if a < b else col_name
+    #     dst_col = col_name if a < b else rev_col_name
+    #     src_coll = self._collection_name if a < b else rev_coll
+    #     dst_coll = rev_coll if a < b else self._collection_name
+    #     return (
+    #         table_name,
+    #         src_coll,
+    #         dst_coll,
+    #         src_col,
+    #         dst_col,
+    #     )
+
+    def _for_each_many_many(self, callback):
+        for col_name, col_data in self._scheme.items():
+            if self._is_many_many_relationship(col_data):
+                table_structure = (
+                    self._many_many_table_structure(col_name, col_data)
+                )
+                yield callback(*table_structure)
+
     def _many_many_table_structure(self, col_name, col_data):
         """
-        Generate name for intermediate table of many-many relationship
+        Generate name and column mapping for an intermediate many-to-many join table.
         """
-        rev_coll = col_data["collection"]
-        rev_col_name = col_data["reverse"][2:]  # Tricky for now
-        a = f"{self._collection_name}_{col_name}_{rev_coll}"
-        b = f"{rev_coll}_{rev_col_name}_{self._collection_name}"
-        table_name = a if a < b else b
-        src_col = rev_col_name if a < b else col_name
-        dst_col = col_name if a < b else rev_col_name
-        src_coll = self._collection_name if a < b else rev_coll
-        dst_coll = rev_coll if a < b else self._collection_name
+        # 1. Extract and clean the collection names and fields
+        source_coll = self._collection_name
+        target_coll = col_data["collection"]
+
+        # If it's a fixed prefix, consider using .lstrip() or .removeprefix() instead of slicing
+        target_col_name = col_data["reverse"][2:] 
+        source_col_name = col_name
+
+        # 2. Determine a deterministic order so TableA->TableB and TableB->TableA resolve identically
+        # We pack the related entities into standardized pairs
+        sources = (source_coll, source_col_name)
+        targets = (target_coll, target_col_name)
+
+        # Sort lexicographically based on the collection names
+        first_side, second_side = sorted([sources, targets], key=lambda x: x[0])
+
+        # 3. Construct the table name cleanly
+        table_name = f"{first_side[0]}_{first_side[1]}_{second_side[0]}"
+        
         return (
             table_name,
-            src_coll,
-            dst_coll,
-            src_col,
-            dst_col,
+            first_side[0],  # source_coll (lexicographically first collection)
+            second_side[0], # target_coll (lexicographically second collection)
+            second_side[1],  # src_col
+            first_side[1], # dst_col
         )
+
+    def _create_join_table_request(self, table_structure):
+        """
+        Generate the SQL query to create an intermediate join table for a 
+        many-to-many relationship.
+
+        Args:
+            table_structure (tuple): A 5-element tuple containing:
+                (table_name, source_coll, target_coll, source_col_name, target_col_name)
+
+        Returns:
+            str: A raw SQL 'CREATE TABLE' query string.
+        """
+        # Unpack the deterministic table and column metadata
+        table_name, source_coll, target_coll, source_col_name, target_col_name = table_structure
+        return f"""
+        CREATE TABLE IF NOT EXISTS {table_name} (
+            {source_col_name} TEXT ,
+            {target_col_name} TEXT ,
+            FOREIGN KEY ({source_col_name}) REFERENCES {source_coll}(_id) ,
+            FOREIGN KEY ({target_col_name}) REFERENCES {target_coll}(_id) ,
+            PRIMARY KEY ({source_col_name}, {target_col_name})
+        );
+        """
 
     def create_table(self):
         """
-        Table creation from schema
+        Create table from the collection schema
         """
         str_cols = []
 
@@ -139,18 +202,11 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         # Generate intermediate tables (many-many relationships)
         for col_name, col_data in self._scheme.items():
             if self._is_many_many_relationship(col_data):
-                table_name, src_coll, dst_coll, src_col, dst_col = (
+                table_structure = (
                     self._many_many_table_structure(col_name, col_data)
                 )
-                str_request = f"""
-                CREATE TABLE IF NOT EXISTS {table_name} (
-                    {src_col} TEXT ,
-                    {dst_col} TEXT ,
-                    FOREIGN KEY ({src_col}) REFERENCES {src_coll}(_id) ,
-                    FOREIGN KEY ({dst_col}) REFERENCES {dst_coll}(_id) ,
-                    PRIMARY KEY ({src_col}, {dst_col})
-                );
-                """
+
+                str_request = self._create_join_table_request(table_structure)
                 log.debug(f"Execute: {str_request}")
                 self._sqlite_try(create_table_execute)
 
@@ -159,22 +215,33 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def delete_all():
             # Delete without condition
-            str_request = f"DELETE FROM {self._collection_name}"
-            log.debug(f"Execute: {str_request}")
-            self._cursor.execute(str_request)
-            # self._con.commit()
+            # str_request = f"DELETE FROM {self._collection_name}"
+            # log.debug(f"Execute: {str_request}")
+            # self._cursor.execute(str_request)
 
             # Delete many-many relationships in intermediate table
-            for col_name, col_data in self._scheme.items():
-                if self._is_many_many_relationship(col_data):
-                    table_name, _, _, _, _ = self._many_many_table_structure(
-                        col_name, col_data
-                    )
+            # for col_name, col_data in self._scheme.items():
+            #     if self._is_many_many_relationship(col_data):
+            #         table_name, _, _, _, _ = self._many_many_table_structure(
+            #             col_name, col_data
+            #         )
 
-                    str_request = f"DELETE FROM {table_name}"
-                    log.debug(f"Execute: {str_request}")
-                    self._cursor.execute(str_request)
+            #         str_request = f"DELETE FROM {table_name}"
+            #         log.debug(f"Execute: {str_request}")
+            #         self._cursor.execute(str_request)
 
+            def _build_delete_request(table_name, *_):
+                return f"DELETE FROM {table_name}"
+
+            # For each many-many field, build a delete request on join table
+            str_requests = list(self._for_each_many_many(_build_delete_request))
+            # Add request for deleting all elements in table of current collection without condition
+            str_requests.append(_build_delete_request(self._collection_name))
+
+            for str_request in str_requests:
+                log.debug(f"Execute: {str_request}")
+                self._cursor.execute(str_request)
+            
             self._con.commit()
 
             # Check how many rows were deleted
@@ -198,7 +265,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         return val
 
-    def _map(self, val, target_types):
+    def _map_val(self, val, target_types):
         if "Bool" in target_types:
             return bool(val)
 
@@ -274,16 +341,33 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         return self._sqlite_try(insert)
 
+    def _map_row(self, row):
+        """
+        Map a row result from SQL to an object
+        """
+        # Create object 
+        # id is always the first column of the row
+        o = {"_id": row[0]}
+
+        for i, (col_name, col_data) in enumerate(self._scheme.items()):
+            col_types = col_data["types"]
+            if "RefsList" not in col_types and not col_name.startswith("_"):
+                o[col_name] = self._map_val(row[i + 1], col_types)
+
+        return o
+
     def get_by_id(self, _id: str) -> dict:
         """See :func:`DBConnector.get_by_id`"""
         log.debug(f"read {_id} ")
 
         def select():
+            # Create and execute request
             str_request = f"SELECT * FROM {self._collection_name} WHERE _id='{_id}'"
             log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request)
             row = self._cursor.fetchone()
 
+            # No results !
             if row is None:
                 raise NotFoundError(
                     '_id "{0}" not found in collection "{1}"',
@@ -291,15 +375,14 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                     self._collection_name,
                 )
 
+            # Retrieve RefsList ids
+            # select love from animals_love_users alu inner join animals a on a._id = alu.is_loved_by where a._id = 5397748549235068761
+
+
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 
-            o = {"_id": row[0]}
-            for i, (col_name, col_data) in enumerate(self._scheme.items()):
-                col_types = col_data["types"]
-                if "RefsList" not in col_types and not col_name.startswith("_"):
-                    o[col_name] = self._map(row[i + 1], col_data["types"])
-
-            return o
+            # Map row result to object and return
+            return self._map_row(row)
 
         return self._sqlite_try(select)
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -1,0 +1,244 @@
+"""
+Module providing the Test DB like
+"""
+
+# pylint: disable=logging-fstring-interpolation
+import os
+import sys
+import re
+import sqlite3
+
+# used for developpement
+sys.path.insert(1, "../../stricto")
+
+from stricto import Kparse
+
+from .db_connector import DBConnector
+from .error import NotFoundError, DBError
+from .log import log_system
+
+
+KPARSE_MODEL = {
+    "path": {"type": str, "default": "/tmp"}, 
+    "dbname": {"type": str, "default": "default"},
+    "collection": {"type": str, "default": ""}
+}
+
+log = log_system.get_or_create_logger("test")
+
+
+class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attributes
+    """Test SQL Connector
+
+    This is the way to save / store / retrieve objects in yaml files
+
+    :param ``**kwargs``:
+        - *path=* ``str`` -- The directory to store yaml files
+
+
+    """
+
+    def __init__(self, **kwargs):
+        """constructor"""
+
+        options = Kparse(kwargs, KPARSE_MODEL)
+
+        self._path = options.get("path")
+        self._dbname = options.get("dbname")
+        self._collection_name = options.get("collection")
+
+        DBConnector.__init__(self, **kwargs)
+
+        if not os.path.exists(self._path):
+            os.makedirs(self._path)
+
+        if not os.path.isdir(self._path):
+            raise DBError('SQLLite path "{0}" is not a directory', self._path)
+
+        try:
+            self._con = sqlite3.connect(f"{self._path}/{self._dbname}.db")
+            self._cursor = self._con.cursor()
+        except Exception as e:
+            raise DBError(
+                'SQLLite connection error at "{0}"', self._path
+            ) from e
+
+
+        # if self.restriction_filter is not None:
+        #     raise DBError("Restriction filter not implemented for yml")
+
+    # def connect(self):
+    #     try:
+    #         self._cursor = self._con.cursor()
+    #     except Exception as e:
+    #         raise DBError(
+    #             'SQLLite connection error at "{0}"', self._path
+    #         ) from e
+
+    def _to_sql_type(self, str_type):
+        return {
+            'String': 'TEXT',
+            "Bool": "INTEGER"
+        }[str_type]
+
+    def create_table(self, meta):
+        str_cols = []
+        
+        print(f"TABLE {meta["name"]}")
+
+        for col_name, col_data in meta["item"]["sub_scheme"].items():
+            if not col_name.startswith("_"):
+                col_type = col_data["types"][0]
+                str_cols.append(f"{col_name} {self._to_sql_type(col_type)}")
+                print(f"COL: {col_name}")
+                print(f"TYPE: {col_type}")
+
+        str_request = f"""
+        CREATE TABLE IF NOT EXISTS {meta["name"]} (
+            id INTEGER PRIMARY KEY, 
+            {",".join(str_cols)}
+        );
+        """
+        print(str_request)
+        
+        try:
+            self._cursor.execute(str_request)
+            self._con.commit()
+            print(self._cursor)
+
+        except sqlite3.OperationalError as e:
+            print(f"✗ Operational Error: {e}")
+        except sqlite3.IntegrityError as e:
+            print(f"✗ Integrity Error: {e}")
+        except sqlite3.ProgrammingError as e:
+            print(f"✗ Programming Error: {e}")
+        except sqlite3.Error as e:
+            print(f"✗ Database Error: {e}")
+        # finally:
+
+    def drop(self) -> None:
+        """See :func:`DBConnector.drop`"""
+        try:
+            # Delete without condition
+            print(self._dbname)
+            print(self._path)
+            self._cursor.execute(f"DELETE FROM {self._collection_name}")
+            self._con.commit()
+            
+            # Check how many rows were deleted
+            deleted_rows = self._cursor.rowcount
+            print(f"✓ Deleted {deleted_rows} row(s)")
+            
+            if deleted_rows == 0:
+                print("⚠ Warning: No rows matched the condition")
+            
+        except sqlite3.OperationalError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Operational Error: {e} while "{self._collection_name}.drop()"'
+            ) from e
+        except sqlite3.IntegrityError as e:
+            print(f"✗ Integrity Error: {e}")
+            self._con.rollback()
+        except sqlite3.Error as e:
+            print(f"✗ Database Error: {e}")
+            self._con.rollback()
+        # finally:
+        #     if conn:
+        #         conn.close()
+
+
+    def save(self, _id: str, o: dict) -> None:
+        """See :func:`DBConnector.save`"""
+        log.debug(f"save {_id} ")
+
+        try:
+            # Insert
+
+            str_request = f'INSERT INTO users (name, surname, male) VALUES ({o["name"]}, {o["surname"]}, TRUE)'
+            print(str_request)
+            self._cursor.execute()
+            self._con.commit()
+            
+            # Check how many rows were deleted
+            # deleted_rows = self._cursor.rowcount
+            # print(f"✓ Deleted {deleted_rows} row(s)")
+            
+            # if deleted_rows == 0:
+            #     print("⚠ Warning: No rows matched the condition")
+            
+        except sqlite3.OperationalError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Operational Error: {e} while "{self._collection_name}.save()"'
+            ) from e
+        except sqlite3.IntegrityError as e:
+            print(f"✗ Integrity Error: {e}")
+            self._con.rollback()
+        except sqlite3.Error as e:
+            print(f"✗ Database Error: {e}")
+            self._con.rollback()
+
+
+    def create(self, o: dict) -> str:
+        """See :func:`DBConnector.create`"""
+        return -1
+        # _id = o["_id"]
+
+        # log.debug(f"create {_id} ")
+        # filename = os.path.join(self._path, _id + ".yml")
+
+        # if os.path.exists(filename):
+        #     raise DBError('_id "{0}" already exist in path "{1}"', _id, self._path)
+
+        # log.debug(f"try to create {filename}")
+        # with open(filename, mode="w", encoding="utf-8") as outfile:
+        #     yaml.dump(o, outfile, default_flow_style=False)
+        # return _id
+
+    def get_by_id(self, _id: str) -> dict:
+        """See :func:`DBConnector.get_by_id`"""
+        log.debug(f"read {_id} ")
+
+
+    def delete_by_id(self, _id: str) -> bool:
+        """See :func:`DBConnector.delete_by_id`"""
+        log.debug(f"delete {_id}")
+
+
+    def select(
+        self,
+        select_filter,
+        projection={},
+        page_size=0,
+        num_of_element_to_skip=0,
+        sort_object={"_id": 1},
+    ) -> list:
+        """See :func:`DBConnector.select`
+
+        Params ``select_filter`` and ``projection`` are not used
+
+        """
+        log.debug(
+            "select(%r, %r).sort(%r).skip(%r).limit(%r)",
+            select_filter,
+            projection,
+            sort_object,
+            num_of_element_to_skip,
+            page_size,
+        )
+
+        result_list = []
+
+        return result_list
+
+    def close(self):
+        """Close the SQLLite connection
+
+        :raise DBError: Raise an error in case of database Error
+
+        """
+        try:
+            return self._con.close()
+        except Exception as e:
+            raise DBError('SQLLite close error at "{0}"', self._path) from e

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -11,7 +11,6 @@ import sqlite3
 sys.path.insert(1, "../../stricto")
 
 from stricto import Kparse
-from .api_toolbox import append_path_to_filter
 
 from .db_connector import DBConnector
 from .error import NotFoundError
@@ -73,27 +72,27 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     def get_at_path(self, path, d: dict):
         clean_path = path[2:]
-        chunks = clean_path.split('.')
+        chunks = clean_path.split(".")
         v = d
         for c in chunks:
             if c in v:
                 v = v[c]
             else:
                 return None
-        
+
         return v
 
     def set_at_path(self, path, d: dict, value):
         clean_path = path[2:]
-        chunks = clean_path.split('.')
+        chunks = clean_path.split(".")
         v = d
-        
+
         # Navigate to the parent of the target key
         for c in chunks[:-1]:
             if c not in v:
                 v[c] = {}
             v = v[c]
-        
+
         # Set the value at the final key
         if chunks:
             v[chunks[-1]] = value
@@ -112,25 +111,31 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                     # flat_meta["sub_scheme"][col_name] = col_data
                     flat_meta["sub_scheme"][col_data["path"]] = col_data
                     flat_meta["sub_scheme"][col_data["path"]]["name"] = col_name
-            
+
             return flat_meta
 
         flat_meta = {}
-        for coll_name, coll_meta in meta.items():    
+        for coll_name, coll_meta in meta.items():
             flat_meta[coll_name] = {}
             _rec_flatten_meta(coll_meta, flat_meta[coll_name])
 
         return flat_meta
 
     def _to_sql_type(self, str_type):
-        return {"String": "TEXT", "Bool": "INTEGER", "Int": "INTEGER", "Datetime": "INTEGER", "Ref": "TEXT"}[str_type]
+        return {
+            "String": "TEXT",
+            "Bool": "INTEGER",
+            "Int": "INTEGER",
+            "Datetime": "INTEGER",
+            "Ref": "TEXT",
+        }[str_type]
 
     def _json_path_to_sql_path(self, path):
         # return path[2:].replace(".", "_")
         # return path.replace("$", "\$").replace(".", "\.")
         return path
 
-    def  _sql_path_to_json_path(self, path):
+    def _sql_path_to_json_path(self, path):
         pass
 
     def _is_many_many_relationship(self, col_data):
@@ -362,7 +367,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 if val is not None and "RefsList" not in col_data["types"]:
                     col_value_pairs.append((path, self._format_val(val)))
 
-            str_col_names = ",".join(f"'{field_name}'" for field_name, _ in col_value_pairs)
+            str_col_names = ",".join(
+                f"'{field_name}'" for field_name, _ in col_value_pairs
+            )
             str_values = ",".join(field_value for _, field_value in col_value_pairs)
 
             str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({str_values})"
@@ -412,7 +419,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def select():
             # Create and execute request
-            str_request = f"SELECT * FROM {self._collection_name} WHERE \"$._id\"='{_id}'"
+            str_request = (
+                f"SELECT * FROM {self._collection_name} WHERE \"$._id\"='{_id}'"
+            )
             log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request)
             row = self._cursor.fetchone()
@@ -435,16 +444,20 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 str_request = f"SELECT join_table.\"{col_data['col_name']}\" FROM {table_data['name']} join_table INNER JOIN {self._collection_name} cur ON cur.\"$._id\" = join_table.\"{col_data['rev_col_name']}\" WHERE cur.\"$._id\" = '{_id}'"
                 log.debug(f"Execute: {str_request}")
                 self._cursor.execute(str_request)
-                
+
                 col_path = col_data["col_name"]
                 # x = self.get_at_path(col_path, o)
                 # if "is_loved_by" in o:
                 #     print("IS LOVEEE: " + o["is_loved_by"])
 
-
-                self.set_at_path(col_path, o, [
-                    self._map_val(row[col_path], col_types) for row in self._cursor.fetchall()
-                ])
+                self.set_at_path(
+                    col_path,
+                    o,
+                    [
+                        self._map_val(row[col_path], col_types)
+                        for row in self._cursor.fetchall()
+                    ],
+                )
 
                 # append_path_to_filter(o, col_path[2:], [
                 #     self._map_val(row[col_path], col_types) for row in self._cursor.fetchall()
@@ -453,9 +466,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 # o[col_data["col_name"]] = [
                 #     self._map_val(row[0], col_types) for row in self._cursor.fetchall()
                 # ]
-
-
-
 
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -21,6 +21,7 @@ KPARSE_MODEL = {
     "path": {"type": str, "default": "/tmp"},
     "dbname": {"type": str, "default": "default"},
     "collection": {"type": str, "default": ""},
+    "meta": {"type": dict}
 }
 
 log = log_system.get_or_create_logger("test")
@@ -45,6 +46,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         self._path = options.get("path")
         self._dbname = options.get("dbname")
         self._collection_name = options.get("collection")
+        self._meta = options.get("meta")
 
         DBConnector.__init__(self, **kwargs)
 
@@ -63,24 +65,23 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def _to_sql_type(self, str_type):
         return {"String": "TEXT", "Bool": "INTEGER", "Ref": "TEXT"}[str_type]
 
-    def create_table(self, meta):
+    def create_table(self):
         """
         Table creation from schema
         """
         str_cols = []
 
-        for col_name, col_data in meta["sub_scheme"].items():
+        for col_name, col_data in self._meta["sub_scheme"].items():
             col_type = col_data["types"][0]
-            if not col_name.startswith("_") and not (col_type == "RefsList"):
+            if not col_name.startswith("_") and not col_type == "RefsList":
                 str_cols.append(f"{col_name} {self._to_sql_type(col_type)}")
 
 
         # Add one-many relationship
-        for col_name, col_data in meta["sub_scheme"].items():
+        for col_name, col_data in self._meta["sub_scheme"].items():
             col_type = col_data["types"][0]
-            if (col_type == "Ref"):
+            if col_type == "Ref":
                 str_cols.append(f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)")
-                # str_alter_request = f"ALTER TABLE {self._collection_name} ADD CONSTRAINT FK_{self._collection_name}_{col_name} FOREIGN KEY ({col_name}_id) REFERENCES {col_name}(_id)"
                 print(str_cols)
 
         str_request = f"""
@@ -92,13 +93,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         print(str_request)
 
-
-
-
         def create_table_execute():
             self._cursor.execute(str_request)
             self._con.commit()
-            self._meta = meta
 
         self._sqlite_try(create_table_execute)
 
@@ -107,7 +104,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def delete_all():
             # Delete without condition
-            self._cursor.execute(f"DELETE FROM {self._collection_name}")
+            str_request = f"DELETE FROM {self._collection_name}"
+            log.debug(f"Execute: {str_request}")
+            self._cursor.execute(str_request)
             self._con.commit()
 
             # Check how many rows were deleted
@@ -181,11 +180,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             str_col_names = ",".join(field_name for field_name, _ in t)
             str_values = ",".join(field_value for _, field_value in t)
 
-            print(str_col_names)
-            print(str_values)
-
             str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({str_values})"
-
+            log.debug(f"Execute: {str_request}")
             # Insert
             self._cursor.execute(str_request)
             self._con.commit()
@@ -202,7 +198,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def select():
             str_request = f"SELECT * FROM {self._collection_name} WHERE _id='{_id}'"
-            print(str_request)
+            log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request)
             row = self._cursor.fetchone()
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -61,7 +61,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
     def _to_sql_type(self, str_type):
-        return {"String": "TEXT", "Bool": "INTEGER"}[str_type]
+        return {"String": "TEXT", "Bool": "INTEGER", "Ref": "TEXT"}[str_type]
 
     def create_table(self, meta):
         """
@@ -69,14 +69,19 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         str_cols = []
 
-        print(f"TABLE {self._collection_name}")
-
         for col_name, col_data in meta["sub_scheme"].items():
-            if not col_name.startswith("_"):
-                col_type = col_data["types"][0]
+            col_type = col_data["types"][0]
+            if not col_name.startswith("_") and not (col_type == "RefsList"):
                 str_cols.append(f"{col_name} {self._to_sql_type(col_type)}")
-                print(f"COL: {col_name}")
-                print(f"TYPE: {col_type}")
+
+
+        # Add one-many relationship
+        for col_name, col_data in meta["sub_scheme"].items():
+            col_type = col_data["types"][0]
+            if (col_type == "Ref"):
+                str_cols.append(f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)")
+                # str_alter_request = f"ALTER TABLE {self._collection_name} ADD CONSTRAINT FK_{self._collection_name}_{col_name} FOREIGN KEY ({col_name}_id) REFERENCES {col_name}(_id)"
+                print(str_cols)
 
         str_request = f"""
         CREATE TABLE IF NOT EXISTS {self._collection_name} (
@@ -84,30 +89,24 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             {",".join(str_cols)}
         );
         """
+
         print(str_request)
 
-        try:
+
+
+
+        def create_table_execute():
             self._cursor.execute(str_request)
             self._con.commit()
             self._meta = meta
 
-        except sqlite3.OperationalError as e:
-            print(f"✗ Operational Error: {e}")
-        except sqlite3.IntegrityError as e:
-            print(f"✗ Integrity Error: {e}")
-        except sqlite3.ProgrammingError as e:
-            print(f"✗ Programming Error: {e}")
-        except sqlite3.Error as e:
-            print(f"✗ Database Error: {e}")
-        # finally:
+        self._sqlite_try(create_table_execute)
 
     def drop(self) -> None:
         """See :func:`DBConnector.drop`"""
 
         def delete_all():
             # Delete without condition
-            print(self._dbname)
-            print(self._path)
             self._cursor.execute(f"DELETE FROM {self._collection_name}")
             self._con.commit()
 
@@ -172,20 +171,22 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         log.debug(f"create {_id} ")
 
         def insert():
-            str_col_names = ",".join(
-                col_name
-                for col_name, _ in o.items()
-                if not self._is_internal_field(col_name)
-            )
-            str_values = ",".join(
-                self._format_val(val)
-                for col_name, val in o.items()
-                if not self._is_internal_field(col_name)
-            )
+
+            t = []
+            for col_name, col_data in self._meta["sub_scheme"].items():
+                col_types = col_data["types"]
+                if "RefsList" not in col_types and col_name != "_meta":
+                    t.append((col_name, self._format_val(o[col_name])))
+            
+            str_col_names = ",".join(field_name for field_name, _ in t)
+            str_values = ",".join(field_value for _, field_value in t)
+
+            print(str_col_names)
+            print(str_values)
+
+            str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({str_values})"
 
             # Insert
-            str_request = f"INSERT INTO {self._collection_name} (_id, {str_col_names}) VALUES ('{_id}', {str_values})"
-            print(str_request)
             self._cursor.execute(str_request)
             self._con.commit()
 
@@ -216,7 +217,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
             o = {"_id": row[0]}
             for i, (col_name, col_data) in enumerate(self._meta["sub_scheme"].items()):
-                if not col_name.startswith("_"):
+                col_types = col_data["types"]
+                if "RefsList" not in col_types and not col_name.startswith("_"):
                     o[col_name] = self._map(row[i + 1], col_data["types"])
 
             return o

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -5,7 +5,6 @@ Module providing the Test DB like
 # pylint: disable=logging-fstring-interpolation
 import os
 import sys
-import re
 import sqlite3
 
 # used for developpement
@@ -14,7 +13,8 @@ sys.path.insert(1, "../../stricto")
 from stricto import Kparse
 
 from .db_connector import DBConnector
-from .error import NotFoundError, DBError
+# from .error import NotFoundError, DBError
+from .error import DBError
 from .log import log_system
 
 KPARSE_MODEL = {
@@ -75,6 +75,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         return {"String": "TEXT", "Bool": "INTEGER"}[str_type]
 
     def create_table(self, meta):
+        """
+        Table creation from schema
+        """
         str_cols = []
 
         print(f"TABLE {meta["name"]}")
@@ -146,10 +149,10 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def _format_val(self, val):
         if isinstance(val, bool):
             return "TRUE" if val else "FALSE"
-        elif isinstance(val, str):
+        if isinstance(val, str):
             return f"'{val}'"
-        else:
-            return val
+        
+        return val
 
     def _is_internal_field(self, field):
         return field.startswith("_")

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -68,9 +68,32 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
+    def drop_table(self):
+        """
+        Drop tables for current collection
+        """
+
+        # Stack queries
+        str_requests = [f"DROP TABLE IF EXISTS {self._collection_name}"]
+        str_requests += [
+            f"DROP TABLE IF EXISTS {col_data["join_table"]["name"]}"
+            for col_data in self._get_many_to_many_cols_data()
+        ]
+
+        def drop_table_execute():
+            # Execute all stacked queries
+            for str_request in str_requests:
+                log.debug(f"Execute: {str_request}")
+                self._cursor.execute(str_request)
+
+            self._con.commit()
+            log.debug(f"✓ Dropped tables of {self._collection_name}")
+
+        return self._sqlite_try(drop_table_execute)
+
     def create_table(self):
         """
-        Create table from the collection schema
+        Create tables for current collection
         """
 
         # 1. Build create table query
@@ -246,9 +269,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def select():
             # Execute main record query
-            str_request = f'SELECT * FROM {self._collection_name} WHERE "$._id"=?'
-            log.debug(f"Execute: {str_request}")
-            self._cursor.execute(str_request, (_id,))
+            query = f'SELECT * FROM {self._collection_name} WHERE "$._id"=?'
+            log.debug(f"Execute: {query}")
+            self._cursor.execute(query, (_id,))
             row = self._cursor.fetchone()
 
             # No results!
@@ -262,17 +285,23 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             # Map row result to object
             o = self._map_row(row)
 
-            # Stack all RefsList queries before executing
-            refs_queries = []
+            # Stack all many-to-many queries before executing
+            queries = []
             for col_data in self._get_many_to_many_cols_data():
-                str_request, params = self._build_refs_list_query(col_data, _id)
-                refs_queries.append((str_request, params, col_data))
+                query, params = self._build_many_to_many_query(col_data, _id)
+                queries.append((query, params, col_data))
 
-            # Execute all stacked RefsList queries
+            # Stack all many-to-one queries before executing
+            for col_data in self._get_many_to_one_cols_data():
+                query, params = self._build_many_to_one_query(col_data, _id)
+                queries.append((query, params, col_data))
+
+            # Execute all stacked many-to-many queries
             refs_results = []
-            for str_request, params, col_data in refs_queries:
-                log.debug(f"Execute: {str_request}")
-                self._cursor.execute(str_request, params)
+            for query, params, col_data in queries:
+                log.debug(self._collection_name)
+                log.debug(f"Execute: {query} with params {params}")
+                self._cursor.execute(query, params)
                 rows = self._cursor.fetchall()
                 refs_results.append((col_data, rows))
 
@@ -376,13 +405,23 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         Check whether given col is a many-many relationship
         """
-        col_type = col_data["types"][0]
-        if col_type != "RefsList":
+        if "RefsList" not in col_data["types"]:
             return False
 
         rev_coll = col_data["collection"]
         rev_col = col_data["reverse"]
         return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
+
+    def _is_many_to_one(self, col_data):
+        """
+        Check whether given col is a many-one relationship
+        """
+        if "RefsList" not in col_data["types"]:
+            return False
+
+        rev_coll = col_data["collection"]
+        rev_col = col_data["reverse"]
+        return "Ref" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
 
     def _get_scalar_cols(self):
         """
@@ -412,6 +451,21 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             self._many_to_many_data(col_name, col_data)
             for col_name, col_data in self._scheme.items()
             if self._is_many_to_many(col_data)
+        ]
+
+    def _get_many_to_one_cols_data(self):
+        """
+        Filter & get only RefsList - Ref cols
+        """
+        return [
+            {
+                "col_name": col_name,
+                "data": col_data,
+                "rev_col_name": col_data["reverse"],
+                "join_table": {"name": col_data["collection"]},
+            }
+            for col_name, col_data in self._scheme.items()
+            if self._is_many_to_one(col_data)
         ]
 
     def _many_to_many_data(self, col_name, col_data):
@@ -470,8 +524,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         );
         """
 
-    def _build_refs_list_query(self, col_data: dict, _id: str):
-        """Build and return prepared query + params for fetching RefsList data"""
+    def _build_many_to_many_query(self, col_data: dict, _id: str):
+        """Build and return prepared query + params for fetching many to many data"""
         table_name = col_data["join_table"]["name"]
         col_name = col_data["col_name"]
         rev_col_name = col_data["rev_col_name"]
@@ -482,6 +536,21 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             INNER JOIN {self._collection_name} cur
             ON cur."$._id" = join_table."{rev_col_name}"
             WHERE cur."$._id" = ?
+        """
+        return query, (_id,)
+
+    def _build_many_to_one_query(self, col_data: dict, _id: str):
+        """Build and return prepared query + params for fetching many to one data"""
+        table_name = col_data["join_table"]["name"]
+        col_name = col_data["col_name"]
+        rev_col_name = col_data["rev_col_name"]
+
+        query = f"""
+            SELECT rev.\"$._id\" AS \"{col_name}\"
+            FROM {table_name} rev
+            INNER JOIN {self._collection_name} cur
+            ON rev.\"{rev_col_name}\" = cur.\"$._id\"
+            WHERE cur.\"$._id\" = ?
         """
         return query, (_id,)
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -53,10 +53,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             "sub_scheme"
         ]  # Shortcut to data
 
-        # Add shortcut to fields (extracted from scheme)
-        # Add shortcut to one-many (extracted from scheme)
-        # Add shortcut to many-many (extracted from scheme)
-
         DBConnector.__init__(self, **kwargs)
 
         if not os.path.exists(self._path):
@@ -72,66 +68,22 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
-    def _flatten_meta(self, meta):
-        """
-        Flatten metadata to get all nested fields at the same level,
-        key becomes the field path instead of field name
-        """
-
-        def _rec_flatten_meta(meta, flat_meta):
-            for col_name, col_data in meta["sub_scheme"].items():
-                types = col_data["types"]
-
-                if "Dict" in types:
-                    _rec_flatten_meta(col_data, flat_meta)
-                else:
-                    if "sub_scheme" not in flat_meta:
-                        flat_meta["sub_scheme"] = {}
-                    # flat_meta["sub_scheme"][col_name] = col_data
-                    flat_meta["sub_scheme"][col_data["path"]] = col_data
-                    flat_meta["sub_scheme"][col_data["path"]]["name"] = col_name
-
-            return flat_meta
-
-        flat_meta = {}
-        for coll_name, coll_meta in meta.items():
-            flat_meta[coll_name] = {}
-            _rec_flatten_meta(coll_meta, flat_meta[coll_name])
-
-        return flat_meta
-
-    def _to_sql_type(self, str_type: str) -> str:
-        """
-        Convert stricto type (string) to SQL type
-        Note: Non exhaustive !
-        """
-        return {
-            "String": "TEXT",
-            "Bool": "INTEGER",
-            "Int": "INTEGER",
-            "Float": "REAL",
-            "Datetime": "INTEGER",
-            "Ref": "TEXT",
-        }[str_type]
-
     def create_table(self):
         """
         Create table from the collection schema
         """
-        str_cols = []
 
-        for col_name, col_data in self._scheme.items():
-            col_type = col_data["types"][0]
-            if not col_type == "RefsList":
-                str_cols.append(f"'{col_name}' {self._to_sql_type(col_type)}")
-
+        # 1. Build create table query
+        # Add scalar cols
+        str_cols = [
+            f"'{col_name}' {self._to_sql_type(col_data["types"][0])}"
+            for col_name, col_data in self._get_scalar_cols()
+        ]
         # Add one-many relationship
-        for col_name, col_data in self._scheme.items():
-            col_type = col_data["types"][0]
-            if col_type == "Ref":
-                str_cols.append(
-                    f"FOREIGN KEY ('{col_name}') REFERENCES {col_data["collection"]}(_id)"
-                )
+        str_cols += [
+            f"FOREIGN KEY ('{col_name}') REFERENCES {col_data["collection"]}(_id)"
+            for col_name, col_data in self._get_one_to_many_cols_data()
+        ]
 
         str_request = f"""
         CREATE TABLE IF NOT EXISTS {self._collection_name} (
@@ -236,7 +188,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 (col_path, self.get_at_path(col_path, o))
                 for col_path, col_data in self._scheme.items()
                 if (val := self.get_at_path(col_path, o)) is not None
-                and not self._is_ref(col_data)
+                and not self._is_ref_list(col_data)
             ]
             col_names = [col_path for col_path, _ in scalar_cols]
             col_values = [val for _, val in scalar_cols]
@@ -417,7 +369,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     # --- Columns & meta utils functions ---
 
-    def _is_ref(self, col_data):
+    def _is_ref_list(self, col_data):
         return "RefsList" in col_data["types"]
 
     def _is_many_to_many(self, col_data):
@@ -432,9 +384,29 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         rev_col = col_data["reverse"]
         return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
 
+    def _get_scalar_cols(self):
+        """
+        Filter & get only Ref / RefsList cols
+        """
+        return [
+            (col_name, col_data)
+            for col_name, col_data in self._scheme.items()
+            if not self._is_ref_list(col_data)
+        ]
+
+    def _get_one_to_many_cols_data(self):
+        """
+        Filter & get only Ref cols
+        """
+        return [
+            (col_name, col_data)
+            for col_name, col_data in self._scheme.items()
+            if "Ref" in col_data["types"]
+        ]
+
     def _get_many_to_many_cols_data(self):
         """
-        Extract some interesting data from col that are many-to-many relationships
+        Filter & get only RefsList - RefsList cols
         """
         return [
             self._many_to_many_data(col_name, col_data)
@@ -541,6 +513,20 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         return o
 
+    def _to_sql_type(self, str_type: str) -> str:
+        """
+        Convert stricto type (string) to SQL type
+        Note: Non exhaustive !
+        """
+        return {
+            "String": "TEXT",
+            "Bool": "INTEGER",
+            "Int": "INTEGER",
+            "Float": "REAL",
+            "Datetime": "INTEGER",
+            "Ref": "TEXT",
+        }[str_type]
+
     # --- Dict utils functions ---
     # Note: some utils functions, just for test, not production ready !
     # Should not be in this class...
@@ -579,3 +565,31 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         # Set the value at the final key
         if chunks:
             v[chunks[-1]] = value
+
+    def _flatten_meta(self, meta):
+        """
+        Flatten metadata to get all nested fields at the same level,
+        key becomes the field path instead of field name
+        """
+
+        def _rec_flatten_meta(meta, flat_meta):
+            for col_name, col_data in meta["sub_scheme"].items():
+                types = col_data["types"]
+
+                if "Dict" in types:
+                    _rec_flatten_meta(col_data, flat_meta)
+                else:
+                    if "sub_scheme" not in flat_meta:
+                        flat_meta["sub_scheme"] = {}
+                    # flat_meta["sub_scheme"][col_name] = col_data
+                    flat_meta["sub_scheme"][col_data["path"]] = col_data
+                    flat_meta["sub_scheme"][col_data["path"]]["name"] = col_name
+
+            return flat_meta
+
+        flat_meta = {}
+        for coll_name, coll_meta in meta.items():
+            flat_meta[coll_name] = {}
+            _rec_flatten_meta(coll_meta, flat_meta[coll_name])
+
+        return flat_meta

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -47,6 +47,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         self._dbname = options.get("dbname")
         self._collection_name = options.get("collection")
         self._meta = options.get("meta")
+        self._scheme = self._meta[self._collection_name]["sub_scheme"] # Shortcut to data
 
         DBConnector.__init__(self, **kwargs)
 
@@ -71,14 +72,14 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         str_cols = []
 
-        for col_name, col_data in self._meta["sub_scheme"].items():
+        for col_name, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if not col_name.startswith("_") and not col_type == "RefsList":
                 str_cols.append(f"{col_name} {self._to_sql_type(col_type)}")
 
 
         # Add one-many relationship
-        for col_name, col_data in self._meta["sub_scheme"].items():
+        for col_name, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if col_type == "Ref":
                 str_cols.append(f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)")
@@ -172,7 +173,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         def insert():
 
             t = []
-            for col_name, col_data in self._meta["sub_scheme"].items():
+            for col_name, col_data in self._scheme.items():
                 col_types = col_data["types"]
                 if "RefsList" not in col_types and col_name != "_meta":
                     t.append((col_name, self._format_val(o[col_name])))
@@ -212,7 +213,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 
             o = {"_id": row[0]}
-            for i, (col_name, col_data) in enumerate(self._meta["sub_scheme"].items()):
+            for i, (col_name, col_data) in enumerate(self._scheme.items()):
                 col_types = col_data["types"]
                 if "RefsList" not in col_types and not col_name.startswith("_"):
                     o[col_name] = self._map(row[i + 1], col_data["types"])

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -46,7 +46,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         self._path = options.get("path")
         self._dbname = options.get("dbname")
         self._collection_name = options.get("collection")
-        self._meta = options.get("meta")
+        self._meta = self._flatten_meta(options.get("meta"))
         self._scheme = self._meta[self._collection_name][
             "sub_scheme"
         ]  # Shortcut to data
@@ -65,6 +65,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         try:
             self._con = sqlite3.connect(f"{self._path}/{self._dbname}.db")
+            self._con.row_factory = sqlite3.Row
             self._cursor = self._con.cursor()
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
@@ -76,7 +77,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 types = col_data["types"]
 
                 if "Dict" in types:
-                    print(f"FOUND DICT: {col_name}" )
                     _rec_flatten_meta(col_data, flat_meta)
                 else:
                     if "sub_scheme" not in flat_meta:
@@ -88,13 +88,12 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         flat_meta = {}
         for coll_name, coll_meta in meta.items():    
             flat_meta[coll_name] = {}
-            print(f"PARSE {coll_name}")
             _rec_flatten_meta(coll_meta, flat_meta[coll_name])
 
         return flat_meta
 
     def _to_sql_type(self, str_type):
-        return {"String": "TEXT", "Bool": "INTEGER", "Ref": "TEXT"}[str_type]
+        return {"String": "TEXT", "Bool": "INTEGER", "Int": "INTEGER", "Datetime": "INTEGER", "Ref": "TEXT"}[str_type]
 
     def _is_many_many_relationship(self, col_data):
         """
@@ -220,7 +219,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         ]
 
         for str_request in str_requests:
-            log.debug(f"Execute: {str_request}")
             self._sqlite_try(create_table_execute)
 
     def drop(self) -> None:
@@ -271,6 +269,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         return val
 
     def _map_val(self, val, target_types):
+        print(val)
+        print(target_types)
         if "Bool" in target_types:
             return bool(val)
         if "Int" in target_types:
@@ -318,7 +318,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             t = []
             for col_name, col_data in self._scheme.items():
                 # Exclude RefsList and _meta columns for insert
-                if "RefsList" not in col_data["types"] and col_name != "_meta":
+                if "RefsList" not in col_data["types"] and col_name != "_meta" and col_name in o:
                     t.append((col_name, self._format_val(o[col_name])))
 
             str_col_names = ",".join(field_name for field_name, _ in t)
@@ -353,14 +353,12 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         Map a row result from SQL to an object
         """
-        # Create object
-        # id is always the first column of the row
-        o = {"_id": row[0]}
-
-        for i, (col_name, col_data) in enumerate(self._scheme.items()):
+        o = {}
+        for col_name, col_data in self._scheme.items():
             col_types = col_data["types"]
-            if "RefsList" not in col_types and not col_name.startswith("_"):
-                o[col_name] = self._map_val(row[i + 1], col_types)
+
+            if col_name in row and "RefsList" not in col_types:
+                o[col_name] = self._map_val(row[col_name], col_types)
 
         return o
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -21,7 +21,7 @@ KPARSE_MODEL = {
     "path": {"type": str, "default": "/tmp"},
     "dbname": {"type": str, "default": "default"},
     "collection": {"type": str, "default": ""},
-    "meta": {"type": dict}
+    "meta": {"type": dict},
 }
 
 log = log_system.get_or_create_logger("test")
@@ -47,7 +47,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         self._dbname = options.get("dbname")
         self._collection_name = options.get("collection")
         self._meta = options.get("meta")
-        self._scheme = self._meta[self._collection_name]["sub_scheme"] # Shortcut to data
+        self._scheme = self._meta[self._collection_name][
+            "sub_scheme"
+        ]  # Shortcut to data
 
         DBConnector.__init__(self, **kwargs)
 
@@ -66,6 +68,34 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def _to_sql_type(self, str_type):
         return {"String": "TEXT", "Bool": "INTEGER", "Ref": "TEXT"}[str_type]
 
+    def _is_many_many_relationship(self, col_data):
+        """
+        Check whether given col is a many-many relationship
+        """
+        col_type = col_data["types"][0]
+        if col_type != "RefsList":
+            return False
+
+        rev_coll = col_data["collection"]
+        rev_col = col_data["reverse"][2:]  # Tricky for now
+        return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
+
+    def _many_many_table_data(self, col_name, col_data):
+        """
+        Generate name for intermediate table of many-many relationship
+        """
+        rev_coll = col_data["collection"]
+        rev_col_name = col_data["reverse"][2:]  # Tricky for now
+        a = f"{self._collection_name}_{col_name}_{rev_coll}"
+        b = f"{rev_coll}_{rev_col_name}_{self._collection_name}"
+        return (
+            a if a < b else b,
+            self._collection_name,
+            rev_coll,
+            col_name,
+            rev_col_name,
+        )
+
     def create_table(self):
         """
         Table creation from schema
@@ -77,13 +107,13 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             if not col_name.startswith("_") and not col_type == "RefsList":
                 str_cols.append(f"{col_name} {self._to_sql_type(col_type)}")
 
-
         # Add one-many relationship
         for col_name, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if col_type == "Ref":
-                str_cols.append(f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)")
-                print(str_cols)
+                str_cols.append(
+                    f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)"
+                )
 
         str_request = f"""
         CREATE TABLE IF NOT EXISTS {self._collection_name} (
@@ -92,13 +122,29 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         );
         """
 
-        print(str_request)
-
         def create_table_execute():
+            log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request)
             self._con.commit()
 
         self._sqlite_try(create_table_execute)
+
+        # Generate intermediate tables (many-many relationships)
+        for col_name, col_data in self._scheme.items():
+            if self._is_many_many_relationship(col_data):
+                table_name, coll0, coll1, col0, col1 = self._many_many_table_data(
+                    col_name, col_data
+                )
+                str_request = f"""
+                CREATE TABLE IF NOT EXISTS {table_name} (
+                    {col0} TEXT ,
+                    {col1} TEXT ,
+                    FOREIGN KEY ({col0}) REFERENCES {coll1}(_id) ,
+                    FOREIGN KEY ({col1}) REFERENCES {coll0}(_id)
+                );
+                """
+                print(str_request)
+                self._sqlite_try(create_table_execute)
 
     def drop(self) -> None:
         """See :func:`DBConnector.drop`"""
@@ -177,7 +223,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 col_types = col_data["types"]
                 if "RefsList" not in col_types and col_name != "_meta":
                     t.append((col_name, self._format_val(o[col_name])))
-            
+
             str_col_names = ",".join(field_name for field_name, _ in t)
             str_values = ",".join(field_value for _, field_value in t)
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -60,17 +60,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
-        # if self.restriction_filter is not None:
-        #     raise DBError("Restriction filter not implemented for yml")
-
-    # def connect(self):
-    #     try:
-    #         self._cursor = self._con.cursor()
-    #     except Exception as e:
-    #         raise DBError(
-    #             'SQLLite connection error at "{0}"', self._path
-    #         ) from e
-
     def _to_sql_type(self, str_type):
         return {"String": "TEXT", "Bool": "INTEGER"}[str_type]
 
@@ -114,7 +103,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     def drop(self) -> None:
         """See :func:`DBConnector.drop`"""
-        try:
+
+        def delete_all():
             # Delete without condition
             print(self._dbname)
             print(self._path)
@@ -128,19 +118,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             if deleted_rows == 0:
                 print("⚠ Warning: No rows matched the condition")
 
-        except sqlite3.OperationalError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Operational Error: {e} while "{self._collection_name}.drop()"'
-            ) from e
-        except sqlite3.IntegrityError as e:
-            print(f"✗ Integrity Error: {e}")
-            self._con.rollback()
-        except sqlite3.Error as e:
-            print(f"✗ Database Error: {e}")
-            self._con.rollback()
-        finally:
-            pass
+        self._sqlite_try(delete_all)
 
     def save(self, _id: str, o: dict) -> None:
         """See :func:`DBConnector.save`"""
@@ -163,6 +141,29 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def _is_internal_field(self, field):
         return field.startswith("_")
 
+    def _sqlite_try(self, callback):
+        """
+        Just a function to factorize
+        the catching of sqlite exceptions
+        """
+        try:
+            return callback()
+        except sqlite3.OperationalError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Operational Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.IntegrityError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Integrity Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.Error as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Database Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+
     def create(self, o: dict) -> str:
         """See :func:`DBConnector.create`"""
         _id = self.generate_id(o)
@@ -170,7 +171,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         log.debug(f"create {_id} ")
 
-        try:
+        def insert():
             str_col_names = ",".join(
                 col_name
                 for col_name, _ in o.items()
@@ -192,34 +193,24 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
             return _id
 
-        except sqlite3.OperationalError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Operational Error: {e} while "{self._collection_name}.create()"'
-            ) from e
-        except sqlite3.IntegrityError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Integrity Error: {e} while "{self._collection_name}.create()"'
-            ) from e
-        except sqlite3.Error as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Database Error: {e} while "{self._collection_name}.create()"'
-            ) from e
+        return self._sqlite_try(insert)
 
     def get_by_id(self, _id: str) -> dict:
         """See :func:`DBConnector.get_by_id`"""
         log.debug(f"read {_id} ")
 
-        try:
-            # Select by id
+        def select():
             str_request = f"SELECT * FROM {self._collection_name} WHERE _id='{_id}'"
             print(str_request)
             self._cursor.execute(str_request)
             row = self._cursor.fetchone()
 
-            print(row)
+            if row is None:
+                raise NotFoundError(
+                    '_id "{0}" not found in collection "{1}"',
+                    _id,
+                    self._collection_name,
+                )
 
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 
@@ -228,30 +219,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 if not col_name.startswith("_"):
                     o[col_name] = self._map(row[i + 1], col_data["types"])
 
-            if o is None:
-                raise NotFoundError(
-                    '_id "{0}" not found in collection "{1}"',
-                    _id,
-                    self._collection_name,
-                )
-
             return o
 
-        except sqlite3.OperationalError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Operational Error: {e} while "{self._collection_name}.create()"'
-            ) from e
-        except sqlite3.IntegrityError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Integrity Error: {e} while "{self._collection_name}.create()"'
-            ) from e
-        except sqlite3.Error as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Database Error: {e} while "{self._collection_name}.create()"'
-            ) from e
+        return self._sqlite_try(select)
 
     def delete_by_id(self, _id: str) -> bool:
         """See :func:`DBConnector.delete_by_id`"""

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -51,6 +51,10 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             "sub_scheme"
         ]  # Shortcut to data
 
+        # Add shortcut to fields (extracted from scheme)
+        # Add shortcut to one-many (extracted from scheme)
+        # Add shortcut to many-many (extracted from scheme)
+
         DBConnector.__init__(self, **kwargs)
 
         if not os.path.exists(self._path):
@@ -82,34 +86,15 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         ]  # Tricky for now need to select actual field $.my.path.to
         return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
 
-    # def _many_many_table_structure(self, col_name, col_data):
-    #     """
-    #     Generate name for intermediate table of many-many relationship
-    #     """
-    #     rev_coll = col_data["collection"]
-    #     rev_col_name = col_data["reverse"][2:]  # Tricky for now
-    #     a = f"{self._collection_name}_{col_name}_{rev_coll}"
-    #     b = f"{rev_coll}_{rev_col_name}_{self._collection_name}"
-    #     table_name = a if a < b else b
-    #     src_col = rev_col_name if a < b else col_name
-    #     dst_col = col_name if a < b else rev_col_name
-    #     src_coll = self._collection_name if a < b else rev_coll
-    #     dst_coll = rev_coll if a < b else self._collection_name
-    #     return (
-    #         table_name,
-    #         src_coll,
-    #         dst_coll,
-    #         src_col,
-    #         dst_col,
-    #     )
-
-    def _for_each_many_many(self, callback):
+    def _get_many_many_cols(self):
+        """
+        Loop over all columns of collection item and call the
+        callback function for columns that are many-many relationship
+        then stack results into a generator
+        """
         for col_name, col_data in self._scheme.items():
             if self._is_many_many_relationship(col_data):
-                table_structure = (
-                    self._many_many_table_structure(col_name, col_data)
-                )
-                yield callback(*table_structure)
+                yield self._many_many_table_structure(col_name, col_data)
 
     def _many_many_table_structure(self, col_name, col_data):
         """
@@ -120,7 +105,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         target_coll = col_data["collection"]
 
         # If it's a fixed prefix, consider using .lstrip() or .removeprefix() instead of slicing
-        target_col_name = col_data["reverse"][2:] 
+        target_col_name = col_data["reverse"][2:]
         source_col_name = col_name
 
         # 2. Determine a deterministic order so TableA->TableB and TableB->TableA resolve identically
@@ -133,18 +118,23 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         # 3. Construct the table name cleanly
         table_name = f"{first_side[0]}_{first_side[1]}_{second_side[0]}"
-        
-        return (
-            table_name,
-            first_side[0],  # source_coll (lexicographically first collection)
-            second_side[0], # target_coll (lexicographically second collection)
-            second_side[1],  # src_col
-            first_side[1], # dst_col
-        )
 
-    def _create_join_table_request(self, table_structure):
+        return {
+            "col_name": col_name,
+            "data": col_data,
+            "rev_col_name": target_col_name,
+            "join_table": {
+                "name": table_name,
+                "source_coll": first_side[0],
+                "target_coll": second_side[0],
+                "source_col": second_side[1],
+                "target_col": first_side[1],
+            },
+        }
+
+    def _build_join_table_request(self, col_data):
         """
-        Generate the SQL query to create an intermediate join table for a 
+        Generate the SQL query to create an intermediate join table for a
         many-to-many relationship.
 
         Args:
@@ -154,15 +144,15 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         Returns:
             str: A raw SQL 'CREATE TABLE' query string.
         """
-        # Unpack the deterministic table and column metadata
-        table_name, source_coll, target_coll, source_col_name, target_col_name = table_structure
+        # Get data of intermediate table
+        table_data = col_data["join_table"]
         return f"""
-        CREATE TABLE IF NOT EXISTS {table_name} (
-            {source_col_name} TEXT ,
-            {target_col_name} TEXT ,
-            FOREIGN KEY ({source_col_name}) REFERENCES {source_coll}(_id) ,
-            FOREIGN KEY ({target_col_name}) REFERENCES {target_coll}(_id) ,
-            PRIMARY KEY ({source_col_name}, {target_col_name})
+        CREATE TABLE IF NOT EXISTS {table_data['name']} (
+            {table_data['source_col']} TEXT ,
+            {table_data['target_col']} TEXT ,
+            FOREIGN KEY ({table_data['source_col']}) REFERENCES {table_data['source_coll']}(_id) ,
+            FOREIGN KEY ({table_data['target_col']}) REFERENCES {table_data['target_coll']}(_id) ,
+            PRIMARY KEY ({table_data['source_col']}, {table_data['target_col']})
         );
         """
 
@@ -200,48 +190,38 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         self._sqlite_try(create_table_execute)
 
         # Generate intermediate tables (many-many relationships)
-        for col_name, col_data in self._scheme.items():
-            if self._is_many_many_relationship(col_data):
-                table_structure = (
-                    self._many_many_table_structure(col_name, col_data)
-                )
+        str_requests = [
+            self._build_join_table_request(col_data)
+            for col_data in self._get_many_many_cols()
+        ]
 
-                str_request = self._create_join_table_request(table_structure)
-                log.debug(f"Execute: {str_request}")
-                self._sqlite_try(create_table_execute)
+        for str_request in str_requests:
+            log.debug(f"Execute: {str_request}")
+            self._sqlite_try(create_table_execute)
 
     def drop(self) -> None:
         """See :func:`DBConnector.drop`"""
 
+        # Function to create SQL request string
+        def build_delete_request(table_name):
+            return f"DELETE FROM {table_name}"
+
+        # For each many-many field, build a delete request on join table
+        str_requests = [
+            build_delete_request(col_data["join_table"]["name"])
+            for col_data in self._get_many_many_cols()
+        ]
+        # Add request for deleting all elements in table of current collection without condition
+        str_requests.append(build_delete_request(self._collection_name))
+
+        # Execute and commit delete requests
         def delete_all():
-            # Delete without condition
-            # str_request = f"DELETE FROM {self._collection_name}"
-            # log.debug(f"Execute: {str_request}")
-            # self._cursor.execute(str_request)
-
-            # Delete many-many relationships in intermediate table
-            # for col_name, col_data in self._scheme.items():
-            #     if self._is_many_many_relationship(col_data):
-            #         table_name, _, _, _, _ = self._many_many_table_structure(
-            #             col_name, col_data
-            #         )
-
-            #         str_request = f"DELETE FROM {table_name}"
-            #         log.debug(f"Execute: {str_request}")
-            #         self._cursor.execute(str_request)
-
-            def _build_delete_request(table_name, *_):
-                return f"DELETE FROM {table_name}"
-
-            # For each many-many field, build a delete request on join table
-            str_requests = list(self._for_each_many_many(_build_delete_request))
-            # Add request for deleting all elements in table of current collection without condition
-            str_requests.append(_build_delete_request(self._collection_name))
-
+            # Execute all delete requests
             for str_request in str_requests:
                 log.debug(f"Execute: {str_request}")
                 self._cursor.execute(str_request)
-            
+
+            # Commit !
             self._con.commit()
 
             # Check how many rows were deleted
@@ -251,6 +231,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             if deleted_rows == 0:
                 log.warning("No rows matched the condition")
 
+        # Effectively try to execute SQL requests
         self._sqlite_try(delete_all)
 
     def save(self, _id: str, o: dict) -> None:
@@ -268,6 +249,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def _map_val(self, val, target_types):
         if "Bool" in target_types:
             return bool(val)
+        if "Int" in target_types:
+            return int(val)
 
         return val
 
@@ -299,6 +282,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     def create(self, o: dict) -> str:
         """See :func:`DBConnector.create`"""
+        # Generate new id and set to object
+        # Note: doesn't support integer & auto increment id for now
         _id = self.generate_id(o)
         o["_id"] = _id
 
@@ -320,16 +305,14 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             # Insert
             log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request)
-            # self._con.commit()
 
             # Insert many-many relationships in intermediate table
             for col_name, col_data in self._scheme.items():
                 if self._is_many_many_relationship(col_data):
-                    table_name, _, _, src_col, dst_col = (
-                        self._many_many_table_structure(col_name, col_data)
-                    )
+                    col_data = self._many_many_table_structure(col_name, col_data)
                     for dst_id in o[col_name]:
-                        str_request = f"INSERT INTO {table_name} ({src_col}, {dst_col}) VALUES ('{_id}', '{dst_id}')"
+                        table_data = col_data["join_table"]
+                        str_request = f"INSERT INTO {table_data['name']} ({col_data['col_name']}, {col_data['rev_col_name']}) VALUES ('{dst_id}', '{_id}')"
                         log.debug(f"Execute: {str_request}")
                         self._cursor.execute(str_request)
 
@@ -345,7 +328,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         Map a row result from SQL to an object
         """
-        # Create object 
+        # Create object
         # id is always the first column of the row
         o = {"_id": row[0]}
 
@@ -375,14 +358,23 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                     self._collection_name,
                 )
 
-            # Retrieve RefsList ids
-            # select love from animals_love_users alu inner join animals a on a._id = alu.is_loved_by where a._id = 5397748549235068761
+            # Map row result to object
+            o = self._map_row(row)
 
+            # Retrieve RefsList ids
+            for col_data in self._get_many_many_cols():
+                col_types = col_data["data"]["types"]
+                table_data = col_data["join_table"]
+                str_request = f"SELECT join_table.{col_data['col_name']} FROM {table_data['name']} join_table INNER JOIN {self._collection_name} cur ON cur._id = join_table.{col_data['rev_col_name']} WHERE cur._id = '{_id}'"
+                self._cursor.execute(str_request)
+                o[col_data["col_name"]] = [
+                    self._map_val(row[0], col_types) for row in self._cursor.fetchall()
+                ]
+                print(str_request)
 
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 
-            # Map row result to object and return
-            return self._map_row(row)
+            return o
 
         return self._sqlite_try(select)
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -171,29 +171,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """See :func:`DBConnector.save`"""
         log.debug(f"save {_id} ")
 
-    def _sqlite_try(self, callback):
-        """
-        Just a function to factorize
-        the catching of sqlite exceptions
-        """
-        try:
-            return callback()
-        except sqlite3.OperationalError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Operational Error: {e} while "{self._collection_name}.create()"'
-            ) from e
-        except sqlite3.IntegrityError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Integrity Error: {e} while "{self._collection_name}.create()"'
-            ) from e
-        except sqlite3.Error as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Database Error: {e} while "{self._collection_name}.create()"'
-            ) from e
-
     def create(self, o: dict) -> str:
         """See :func:`DBConnector.create`"""
         # Generate new id and set to object
@@ -506,6 +483,29 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         }
 
     # --- SQL utils functions ---
+
+    def _sqlite_try(self, callback):
+        """
+        Just a function to factorize
+        the catching of sqlite exceptions
+        """
+        try:
+            return callback()
+        except sqlite3.OperationalError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Operational Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.IntegrityError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Integrity Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.Error as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Database Error: {e} while "{self._collection_name}.create()"'
+            ) from e
 
     def _build_join_table_request(self, col_data):
         """

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -11,6 +11,7 @@ import sqlite3
 sys.path.insert(1, "../../stricto")
 
 from stricto import Kparse
+
 # from .api_toolbox import append_path_to_filter
 
 from .db_connector import DBConnector
@@ -38,21 +39,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
 
     """
-
-    # Note: just for test,
-    # must use prepared queries to avoid this !
-    def _escape_sql_string(self, s):
-        """Escape SQL special characters using translation table"""
-        trans_table = str.maketrans({
-            "'": "''",
-            '"': '""',
-            "\\": "\\\\",
-            "\0": "\\0",
-            "\n": "\\n",
-            "\r": "\\r",
-            "\x1a": "\\Z",
-        })
-        return s.translate(trans_table)
 
     def __init__(self, **kwargs):
         """constructor"""
@@ -86,46 +72,12 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
-    def get_at_path(self, path, d: dict):
-        """
-        Get value of a dict at given JSON path
-        Note: Just a simple implementation to quick test, but does not support array !
-        """
-        clean_path = path[2:]
-        chunks = clean_path.split(".")
-        v = d
-        for c in chunks:
-            if c in v:
-                v = v[c]
-            else:
-                return None
-
-        return v
-
-    def set_at_path(self, path, d: dict, value):
-        """
-        Set value of a dict at given JSON path
-        Note: Just a simple implementation to quick test, but does not support array !
-        """
-        clean_path = path[2:]
-        chunks = clean_path.split(".")
-        v = d
-
-        # Navigate to the parent of the target key
-        for c in chunks[:-1]:
-            if c not in v:
-                v[c] = {}
-            v = v[c]
-
-        # Set the value at the final key
-        if chunks:
-            v[chunks[-1]] = value
-
     def _flatten_meta(self, meta):
         """
         Flatten metadata to get all nested fields at the same level,
         key becomes the field path instead of field name
         """
+
         def _rec_flatten_meta(meta, flat_meta):
             for col_name, col_data in meta["sub_scheme"].items():
                 types = col_data["types"]
@@ -148,7 +100,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         return flat_meta
 
-    def _to_sql_type(self, str_type : str) -> str:
+    def _to_sql_type(self, str_type: str) -> str:
         """
         Convert stricto type (string) to SQL type
         Note: Non exhaustive !
@@ -162,100 +114,23 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             "Ref": "TEXT",
         }[str_type]
 
-    def _is_many_many_relationship(self, col_data):
-        """
-        Check whether given col is a many-many relationship
-        """
-        col_type = col_data["types"][0]
-        if col_type != "RefsList":
-            return False
-
-        rev_coll = col_data["collection"]
-        rev_col = col_data["reverse"]
-        return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
-
-    def _get_many_many_cols(self):
-        """
-        Loop over all columns of collection item and call the
-        callback function for columns that are many-many relationship
-        then stack results into a generator
-        """
-        for col_name, col_data in self._scheme.items():
-            if self._is_many_many_relationship(col_data):
-                yield self._many_many_table_structure(col_name, col_data)
-
-    def _many_many_table_structure(self, col_path, col_data):
-        """
-        Generate name and column mapping for an intermediate many-to-many join table.
-        """
-        # 1. Extract and clean the collection names and fields
-        source_coll = self._collection_name
-        target_coll = col_data["collection"]
-
-        # If it's a fixed prefix, consider using .lstrip() or .removeprefix() instead of slicing
-        target_col_name = col_data["reverse"]
-        source_col_name = col_path
-
-        # 2. Determine a deterministic order so TableA->TableB and TableB->TableA resolve identically
-        # We pack the related entities into standardized pairs
-        sources = (source_coll, source_col_name)
-        targets = (target_coll, target_col_name)
-
-        # Sort lexicographically based on the collection names
-        first_side, second_side = sorted([sources, targets], key=lambda x: x[0])
-
-        # 3. Construct the table name cleanly
-        col = first_side[1].replace("$.", "").replace(".", "_")
-        table_name = f"{first_side[0]}_{col}_{second_side[0]}"
-
-        return {
-            "col_name": col_path,
-            "data": col_data,
-            "rev_col_name": target_col_name,
-            "join_table": {
-                "name": table_name,
-                "source_coll": first_side[0],
-                "target_coll": second_side[0],
-                "source_col": second_side[1],
-                "target_col": first_side[1],
-            },
-        }
-
-    def _build_join_table_request(self, col_data):
-        """
-        Generate the SQL query to create an intermediate join table for a
-        many-to-many relationship.
-        """
-        # Get data of intermediate table
-        table_data = col_data["join_table"]
-        return f"""
-        CREATE TABLE IF NOT EXISTS {table_data['name']} (
-            '{table_data['source_col']}' TEXT ,
-            '{table_data['target_col']}' TEXT ,
-            FOREIGN KEY ('{table_data['source_col']}') REFERENCES {table_data['source_coll']}(_id) ,
-            FOREIGN KEY ('{table_data['target_col']}') REFERENCES {table_data['target_coll']}(_id) ,
-            PRIMARY KEY ('{table_data['source_col']}', '{table_data['target_col']}')
-        );
-        """
-
     def create_table(self):
         """
         Create table from the collection schema
         """
         str_cols = []
 
-        for col_path, col_data in self._scheme.items():
+        for col_name, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if not col_type == "RefsList":
-                str_cols.append(f"'{col_path}' {self._to_sql_type(col_type)}")
+                str_cols.append(f"'{col_name}' {self._to_sql_type(col_type)}")
 
         # Add one-many relationship
-        for col_path, col_data in self._scheme.items():
+        for col_name, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if col_type == "Ref":
                 str_cols.append(
-                    # f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)"
-                    f"FOREIGN KEY ('{col_path}') REFERENCES {col_data["collection"]}(_id)"
+                    f"FOREIGN KEY ('{col_name}') REFERENCES {col_data["collection"]}(_id)"
                 )
 
         str_request = f"""
@@ -275,7 +150,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         # Generate intermediate tables (many-many relationships)
         str_requests = [
             self._build_join_table_request(col_data)
-            for col_data in self._get_many_many_cols()
+            for col_data in self._get_many_to_many_cols_data()
         ]
 
         for str_request in str_requests:
@@ -284,63 +159,42 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def drop(self) -> None:
         """See :func:`DBConnector.drop`"""
 
-        # Function to create SQL request string
-        def build_delete_request(table_name):
-            return f"DELETE FROM {table_name}"
-
-        # For each many-many field, build a delete request on join table
-        str_requests = [
-            build_delete_request(col_data["join_table"]["name"])
-            for col_data in self._get_many_many_cols()
+        # Build list of table names to delete from
+        table_names = [
+            col_data["join_table"]["name"]
+            for col_data in self._get_many_to_many_cols_data()
         ]
-        # Add request for deleting all elements in table of current collection without condition
-        str_requests.append(build_delete_request(self._collection_name))
+        # Add current collection table (must be last to respect foreign keys)
+        table_names.append(self._collection_name)
 
-        # Execute and commit delete requests
         def delete_all():
-            # Execute all delete requests
-            for str_request in str_requests:
+            # Stack all DELETE queries before executing
+            delete_queries = []
+            for table_name in table_names:
+                str_request = f"DELETE FROM {table_name}"
+                delete_queries.append(str_request)
+
+            # Execute all stacked queries
+            deleted_count = 0
+            for str_request in delete_queries:
                 log.debug(f"Execute: {str_request}")
                 self._cursor.execute(str_request)
+                deleted_count += self._cursor.rowcount
 
-            # Commit !
+            # Commit all deletions
             self._con.commit()
 
-            # Check how many rows were deleted
-            deleted_rows = self._cursor.rowcount
-            log.debug(f"✓ Deleted {deleted_rows} row(s)")
+            log.debug(f"✓ Deleted {deleted_count} row(s)")
 
-            if deleted_rows == 0:
+            if deleted_count == 0:
                 log.warning("No rows matched the condition")
 
-        # Effectively try to execute SQL requests
+        # Execute with error handling
         self._sqlite_try(delete_all)
 
     def save(self, _id: str, o: dict) -> None:
         """See :func:`DBConnector.save`"""
         log.debug(f"save {_id} ")
-
-    def _format_val(self, val) -> str:
-        """
-        Format value to SQL string according to its type
-        """
-        if isinstance(val, bool):
-            return "TRUE" if val else "FALSE"
-        if isinstance(val, str):
-            return f"'{self._escape_sql_string(val)}'"
-
-        return str(val)
-
-    def _map_val(self, val, target_types):
-        """
-        Map a value according to given target type
-        """
-        if "Bool" in target_types:
-            return bool(val)
-        if "Int" in target_types:
-            return int(val)
-
-        return val
 
     def _sqlite_try(self, callback):
         """
@@ -375,39 +229,56 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         log.debug(f"create {_id} ")
 
         def insert():
+            # Stack all INSERT queries before executing
 
-            # Collect column names and values in a single pass
-            col_names = []
-            col_values = []
+            # 1. Collect main record insert query
+            scalar_cols = [
+                (col_path, self.get_at_path(col_path, o))
+                for col_path, col_data in self._scheme.items()
+                if (val := self.get_at_path(col_path, o)) is not None
+                and not self._is_ref(col_data)
+            ]
+            col_names = [col_path for col_path, _ in scalar_cols]
+            col_values = [val for _, val in scalar_cols]
 
-            for col_path, col_data in self._scheme.items():
-                val = self.get_at_path(col_path, o)
-                # Exclude RefsList for insert
-                if val is not None and "RefsList" not in col_data["types"]:
-                    col_names.append(col_path)
-                    col_values.append(val)
-
-            # Build prepared query
+            # Build main record insert query
             str_col_names = ",".join(f'"{col_name}"' for col_name in col_names)
             placeholders = ",".join("?" * len(col_values))
-            str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({placeholders})"
+            main_insert = (
+                f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({placeholders})",
+                col_values,
+            )
 
-            # Execute with values passed separately
+            # 2. Collect many-many relationship insert queries
+            many_many_inserts = []
+            for col_data in self._get_many_to_many_cols_data():
+                col_name = col_data["col_name"]
+                val = self.get_at_path(col_name, o)
+
+                if val is None:
+                    continue
+
+                table_data = col_data["join_table"]
+                table_name = table_data["name"]
+                rev_col_name = col_data["rev_col_name"]
+
+                # Prepare batch data: (dst_id, _id) for each relationship
+                batch_data = [(dst_id, _id) for dst_id in val]
+
+                # Build many-many insert query
+                str_request = f'INSERT INTO {table_name} ("{col_name}", "{rev_col_name}") VALUES (?, ?)'
+                many_many_inserts.append((str_request, batch_data))
+
+            # Execute all stacked queries
+            # Main record insert first
+            str_request, col_values = main_insert
             log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request, col_values)
 
-            # Insert many-many relationships in intermediate table
-            for col_path, col_data in self._scheme.items():
-                if self._is_many_many_relationship(col_data):
-                    col_data = self._many_many_table_structure(col_path, col_data)
-                    val = self.get_at_path(col_path, o)
-                    if val is not None:
-                        for dst_id in val:
-                            table_data = col_data["join_table"]
-                            # Note that here we can insert multiple rows in single operation (more effective)
-                            str_request = f"INSERT INTO {table_data['name']} ('{col_path}', '{col_data['rev_col_name']}') VALUES ('{dst_id}', '{_id}')"
-                            log.debug(f"Execute: {str_request}")
-                            self._cursor.execute(str_request)
+            # Many-many relationship inserts
+            for str_request, batch_data in many_many_inserts:
+                log.debug(f"Execute: {str_request}")
+                self._cursor.executemany(str_request, batch_data)
 
             # Commit all requests
             self._con.commit()
@@ -417,38 +288,18 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         return self._sqlite_try(insert)
 
-    def _map_row(self, row):
-        """
-        Map a row result from SQL to an object
-        """
-        o = {}
-        for col_name, col_data in self._scheme.items():
-            col_types = col_data["types"]
-
-            row_dict = dict(row)
-            if col_name in row_dict and "RefsList" not in col_types:
-                val = row[col_name]
-                if val:
-                    map_val = self._map_val(row[col_name], col_types)
-                    self.set_at_path(col_name, o, map_val)
-
-        return o
-
     def get_by_id(self, _id: str) -> dict:
         """See :func:`DBConnector.get_by_id`"""
-        log.debug(f"read {_id} ")
+        log.debug(f"read {_id}")
 
         def select():
-            # Create and execute request using prepared query
-            str_request = (
-                f"SELECT * FROM {self._collection_name} WHERE \"$._id\"=?"
-            )
+            # Execute main record query
+            str_request = f'SELECT * FROM {self._collection_name} WHERE "$._id"=?'
             log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request, (_id,))
             row = self._cursor.fetchone()
 
-
-            # No results !
+            # No results!
             if row is None:
                 raise NotFoundError(
                     '_id "{0}" not found in collection "{1}"',
@@ -456,34 +307,33 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                     self._collection_name,
                 )
 
-
-
             # Map row result to object
             o = self._map_row(row)
 
-            # Retrieve RefsList ids
-            for col_data in self._get_many_many_cols():
-                col_types = col_data["data"]["types"]
-                table_data = col_data["join_table"]
-                str_request = f"SELECT join_table.\"{col_data['col_name']}\" \
-                    FROM {table_data['name']} join_table \
-                    INNER JOIN {self._collection_name} cur \
-                    ON cur.\"$._id\" = join_table.\"{col_data['rev_col_name']}\" \
-                    WHERE cur.\"$._id\" = '{_id}'"
+            # Stack all RefsList queries before executing
+            refs_queries = []
+            for col_data in self._get_many_to_many_cols_data():
+                str_request, params = self._build_refs_list_query(col_data, _id)
+                refs_queries.append((str_request, params, col_data))
 
+            # Execute all stacked RefsList queries
+            refs_results = []
+            for str_request, params, col_data in refs_queries:
                 log.debug(f"Execute: {str_request}")
-                self._cursor.execute(str_request)
+                self._cursor.execute(str_request, params)
+                rows = self._cursor.fetchall()
+                refs_results.append((col_data, rows))
 
-                col_path = col_data["col_name"]
+            # Map all RefsList results to object
+            for col_data, rows in refs_results:
+                col_name = col_data["col_name"]
+                col_types = col_data["data"]["types"]
 
-                self.set_at_path(
-                    col_path,
-                    o,
-                    [
-                        self._map_val(row[col_path], col_types)
-                        for row in self._cursor.fetchall()
-                    ],
-                )
+                mapped_values = [
+                    self._map_val(row[col_name], col_types) for row in rows
+                ]
+
+                self.set_at_path(col_name, o, mapped_values)
 
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 
@@ -494,6 +344,39 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def delete_by_id(self, _id: str) -> bool:
         """See :func:`DBConnector.delete_by_id`"""
         log.debug(f"delete {_id}")
+
+        def delete_record():
+            # Stack all DELETE queries before executing
+            delete_queries = []
+
+            # Stack join table deletions
+            for col_data in self._get_many_to_many_cols_data():
+                table_name = col_data["join_table"]["name"]
+                rev_col_name = col_data["rev_col_name"]
+
+                str_request = f'DELETE FROM {table_name} WHERE "{rev_col_name}" = ?'
+                delete_queries.append((str_request, (_id,)))
+
+            # Stack main record deletion (must be last to respect foreign keys)
+            str_request = f'DELETE FROM {self._collection_name} WHERE "$._id" = ?'
+            delete_queries.append((str_request, (_id,)))
+
+            # Execute all stacked queries
+            deleted_count = 0
+            for str_request, params in delete_queries:
+                log.debug(f"Execute: {str_request}")
+                self._cursor.execute(str_request, params)
+                deleted_count += self._cursor.rowcount
+
+            # Commit all deletions
+            self._con.commit()
+
+            log.debug(f"✓ Deleted {deleted_count} row(s)")
+
+            return deleted_count > 0
+
+        # Execute with error handling and return result
+        return self._sqlite_try(delete_record)
 
     def select(
         self,
@@ -531,3 +414,168 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             return self._con.close()
         except Exception as e:
             raise DBError('SQLLite close error at "{0}"', self._path) from e
+
+    # --- Columns & meta utils functions ---
+
+    def _is_ref(self, col_data):
+        return "RefsList" in col_data["types"]
+
+    def _is_many_to_many(self, col_data):
+        """
+        Check whether given col is a many-many relationship
+        """
+        col_type = col_data["types"][0]
+        if col_type != "RefsList":
+            return False
+
+        rev_coll = col_data["collection"]
+        rev_col = col_data["reverse"]
+        return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
+
+    def _get_many_to_many_cols_data(self):
+        """
+        Extract some interesting data from col that are many-to-many relationships
+        """
+        return [
+            self._many_to_many_data(col_name, col_data)
+            for col_name, col_data in self._scheme.items()
+            if self._is_many_to_many(col_data)
+        ]
+
+    def _many_to_many_data(self, col_name, col_data):
+        """
+        Generate name and column mapping for an intermediate many-to-many join table.
+        """
+        # 1. Extract and clean the collection names and fields
+        source_coll = self._collection_name
+        target_coll = col_data["collection"]
+
+        # If it's a fixed prefix, consider using .lstrip() or .removeprefix() instead of slicing
+        target_col_name = col_data["reverse"]
+        source_col_name = col_name
+
+        # 2. Determine a deterministic order so TableA->TableB and TableB->TableA resolve identically
+        # We pack the related entities into standardized pairs
+        sources = (source_coll, source_col_name)
+        targets = (target_coll, target_col_name)
+
+        # Sort lexicographically based on the collection names
+        first_side, second_side = sorted([sources, targets], key=lambda x: x[0])
+
+        # 3. Construct the table name cleanly
+        col = first_side[1].replace("$.", "").replace(".", "_")
+        table_name = f"{first_side[0]}_{col}_{second_side[0]}"
+
+        return {
+            "col_name": col_name,
+            "data": col_data,
+            "rev_col_name": target_col_name,
+            "join_table": {
+                "name": table_name,
+                "source_coll": first_side[0],
+                "target_coll": second_side[0],
+                "source_col": second_side[1],
+                "target_col": first_side[1],
+            },
+        }
+
+    # --- SQL utils functions ---
+
+    def _build_join_table_request(self, col_data):
+        """
+        Generate the SQL query to create an intermediate join table for a
+        many-to-many relationship.
+        """
+        # Get data of intermediate table
+        table_data = col_data["join_table"]
+        return f"""
+        CREATE TABLE IF NOT EXISTS {table_data['name']} (
+            '{table_data['source_col']}' TEXT ,
+            '{table_data['target_col']}' TEXT ,
+            FOREIGN KEY ('{table_data['source_col']}') REFERENCES {table_data['source_coll']}(_id) ,
+            FOREIGN KEY ('{table_data['target_col']}') REFERENCES {table_data['target_coll']}(_id) ,
+            PRIMARY KEY ('{table_data['source_col']}', '{table_data['target_col']}')
+        );
+        """
+
+    def _build_refs_list_query(self, col_data: dict, _id: str):
+        """Build and return prepared query + params for fetching RefsList data"""
+        table_name = col_data["join_table"]["name"]
+        col_name = col_data["col_name"]
+        rev_col_name = col_data["rev_col_name"]
+
+        query = f"""
+            SELECT join_table."{col_name}"
+            FROM {table_name} join_table
+            INNER JOIN {self._collection_name} cur
+            ON cur."$._id" = join_table."{rev_col_name}"
+            WHERE cur."$._id" = ?
+        """
+        return query, (_id,)
+
+    def _map_val(self, val, target_types):
+        """
+        Map a value according to given target type
+        """
+        if "Bool" in target_types:
+            return bool(val)
+        if "Int" in target_types:
+            return int(val)
+
+        return val
+
+    def _map_row(self, row):
+        """
+        Map a row result from SQL to an object
+        """
+        o = {}
+        for col_name, col_data in self._scheme.items():
+            col_types = col_data["types"]
+
+            row_dict = dict(row)
+            if col_name in row_dict and "RefsList" not in col_types:
+                val = row[col_name]
+                if val:
+                    map_val = self._map_val(row[col_name], col_types)
+                    self.set_at_path(col_name, o, map_val)
+
+        return o
+
+    # --- Dict utils functions ---
+    # Note: some utils functions, just for test, not production ready !
+    # Should not be in this class...
+
+    def get_at_path(self, path, d: dict):
+        """
+        Get value of a dict at given JSON path
+        Note: Just a simple implementation to quick test, but does not support array !
+        """
+        clean_path = path[2:]
+        chunks = clean_path.split(".")
+        v = d
+        for c in chunks:
+            if c in v:
+                v = v[c]
+            else:
+                return None
+
+        return v
+
+    def set_at_path(self, path, d: dict, value):
+        """
+        Set value of a dict at given JSON path
+        Note: Just a simple implementation to quick test, but does not support array !
+        """
+        clean_path = path[2:]
+        chunks = clean_path.split(".")
+        v = d
+
+        # Navigate to the parent of the target key
+        for c in chunks[:-1]:
+            if c not in v:
+                v[c] = {}
+            v = v[c]
+
+        # Set the value at the final key
+        if chunks:
+            v[chunks[-1]] = value

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -63,7 +63,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         try:
             self._con = sqlite3.connect(f"{self._path}/{self._dbname}.db")
-            self._con.row_factory = sqlite3.Row
+            self._con.row_factory = sqlite3.Row # Enable to get a column indexed by name
             self._cursor = self._con.cursor()
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
@@ -376,6 +376,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     # --- Columns & meta utils functions ---
 
     def _is_ref_list(self, col_data):
+        """
+        Check whether given col is a RefsList
+        """
         return "RefsList" in col_data["types"]
 
     def _is_many_to_many(self, col_data):
@@ -402,7 +405,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     def _get_scalar_cols(self):
         """
-        Filter & get only Ref / RefsList cols
+        Get cols that are scalar (Ref or Atomic value)
         """
         return [
             (col_name, col_data)
@@ -412,7 +415,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     def _get_one_to_many_cols_data(self):
         """
-        Filter & get only Ref cols
+        Get cols that are one-to-many relationship (Ref -> ?)
         """
         return [
             (col_name, col_data)
@@ -422,7 +425,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     def _get_many_to_many_cols_data(self):
         """
-        Filter & get only RefsList - RefsList cols
+        Get cols data that are many-to-many relationship
         """
         return [
             self._many_to_many_data(col_name, col_data)
@@ -432,8 +435,11 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
     def _get_many_to_one_cols_data(self):
         """
-        Filter & get only RefsList - Ref cols
+        Get cols that are many-to-one relationship (RefsList -> ?)
         """
+        # Return some data about relationship and join table
+        # in this specific format  (compatbile with _many_to_many_data)
+        # Need to extract this to a class...
         return [
             {
                 "col_name": col_name,
@@ -469,6 +475,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         col = first_side[1].replace("$.", "").replace(".", "_")
         table_name = f"{first_side[0]}_{col}_{second_side[0]}"
 
+        # Return some data about relationship and join table
+        # in this specific format  (compatbile with _get_many_to_one_cols_data)
+        # Need to extract this to a class...
         return {
             "col_name": col_name,
             "data": col_data,
@@ -554,6 +563,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         return query, (_id,)
 
+    # Note: non exhaustive ! need completion
     def _map_val(self, val, target_types):
         """
         Map a value according to given target type
@@ -569,11 +579,13 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         Map a row result from SQL to an object
         """
+        # Create object
         o = {}
+
+        # Get cols that are not RefLists
         for col_name, col_data in self._scheme.items():
             col_types = col_data["types"]
-
-            row_dict = dict(row)
+            row_dict = dict(row) # Need to convert to dict (for indexation)
             if col_name in row_dict and "RefsList" not in col_types:
                 val = row[col_name]
                 if val:

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -17,11 +17,10 @@ from .db_connector import DBConnector
 from .error import NotFoundError, DBError
 from .log import log_system
 
-
 KPARSE_MODEL = {
-    "path": {"type": str, "default": "/tmp"}, 
+    "path": {"type": str, "default": "/tmp"},
     "dbname": {"type": str, "default": "default"},
-    "collection": {"type": str, "default": ""}
+    "collection": {"type": str, "default": ""},
 }
 
 log = log_system.get_or_create_logger("test")
@@ -59,10 +58,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             self._con = sqlite3.connect(f"{self._path}/{self._dbname}.db")
             self._cursor = self._con.cursor()
         except Exception as e:
-            raise DBError(
-                'SQLLite connection error at "{0}"', self._path
-            ) from e
-
+            raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
         # if self.restriction_filter is not None:
         #     raise DBError("Restriction filter not implemented for yml")
@@ -76,14 +72,11 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     #         ) from e
 
     def _to_sql_type(self, str_type):
-        return {
-            'String': 'TEXT',
-            "Bool": "INTEGER"
-        }[str_type]
+        return {"String": "TEXT", "Bool": "INTEGER"}[str_type]
 
     def create_table(self, meta):
         str_cols = []
-        
+
         print(f"TABLE {meta["name"]}")
 
         for col_name, col_data in meta["item"]["sub_scheme"].items():
@@ -94,13 +87,13 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 print(f"TYPE: {col_type}")
 
         str_request = f"""
-        CREATE TABLE IF NOT EXISTS {meta["name"]} (
-            id INTEGER PRIMARY KEY, 
+        CREATE TABLE IF NOT EXISTS {self._collection_name} (
+            _id TEXT PRIMARY KEY, 
             {",".join(str_cols)}
         );
         """
         print(str_request)
-        
+
         try:
             self._cursor.execute(str_request)
             self._con.commit()
@@ -124,14 +117,14 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             print(self._path)
             self._cursor.execute(f"DELETE FROM {self._collection_name}")
             self._con.commit()
-            
+
             # Check how many rows were deleted
             deleted_rows = self._cursor.rowcount
             print(f"✓ Deleted {deleted_rows} row(s)")
-            
+
             if deleted_rows == 0:
                 print("⚠ Warning: No rows matched the condition")
-            
+
         except sqlite3.OperationalError as e:
             self._con.rollback()
             raise DBError(
@@ -143,68 +136,76 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         except sqlite3.Error as e:
             print(f"✗ Database Error: {e}")
             self._con.rollback()
-        # finally:
-        #     if conn:
-        #         conn.close()
-
+        finally:
+            pass
 
     def save(self, _id: str, o: dict) -> None:
         """See :func:`DBConnector.save`"""
         log.debug(f"save {_id} ")
 
-        try:
-            # Insert
+    def _format_val(self, val):
+        if isinstance(val, bool):
+            return "TRUE" if val else "FALSE"
+        elif isinstance(val, str):
+            return f"'{val}'"
+        else:
+            return val
 
-            str_request = f'INSERT INTO users (name, surname, male) VALUES ({o["name"]}, {o["surname"]}, TRUE)'
-            print(str_request)
-            self._cursor.execute()
-            self._con.commit()
-            
-            # Check how many rows were deleted
-            # deleted_rows = self._cursor.rowcount
-            # print(f"✓ Deleted {deleted_rows} row(s)")
-            
-            # if deleted_rows == 0:
-            #     print("⚠ Warning: No rows matched the condition")
-            
-        except sqlite3.OperationalError as e:
-            self._con.rollback()
-            raise DBError(
-                f'✗ Operational Error: {e} while "{self._collection_name}.save()"'
-            ) from e
-        except sqlite3.IntegrityError as e:
-            print(f"✗ Integrity Error: {e}")
-            self._con.rollback()
-        except sqlite3.Error as e:
-            print(f"✗ Database Error: {e}")
-            self._con.rollback()
-
+    def _is_internal_field(self, field):
+        return field.startswith("_")
 
     def create(self, o: dict) -> str:
         """See :func:`DBConnector.create`"""
-        return -1
-        # _id = o["_id"]
+        _id = self.generate_id(o)
+        o["_id"] = _id
 
-        # log.debug(f"create {_id} ")
-        # filename = os.path.join(self._path, _id + ".yml")
+        log.debug(f"create {_id} ")
 
-        # if os.path.exists(filename):
-        #     raise DBError('_id "{0}" already exist in path "{1}"', _id, self._path)
+        try:
+            str_col_names = ",".join(
+                col_name
+                for col_name, _ in o.items()
+                if not self._is_internal_field(col_name)
+            )
+            str_values = ",".join(
+                self._format_val(val)
+                for col_name, val in o.items()
+                if not self._is_internal_field(col_name)
+            )
 
-        # log.debug(f"try to create {filename}")
-        # with open(filename, mode="w", encoding="utf-8") as outfile:
-        #     yaml.dump(o, outfile, default_flow_style=False)
-        # return _id
+            # Insert
+            str_request = f"INSERT INTO {self._collection_name} (_id, {str_col_names}) VALUES ('{_id}', {str_values})"
+            print(str_request)
+            self._cursor.execute(str_request)
+            self._con.commit()
+
+            log.debug(f"✓ Created {self._collection_name} {_id}")
+
+            return _id
+
+        except sqlite3.OperationalError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Operational Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.IntegrityError as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Integrity Error: {e} while "{self._collection_name}.create()"'
+            ) from e
+        except sqlite3.Error as e:
+            self._con.rollback()
+            raise DBError(
+                f'✗ Database Error: {e} while "{self._collection_name}.create()"'
+            ) from e
 
     def get_by_id(self, _id: str) -> dict:
         """See :func:`DBConnector.get_by_id`"""
         log.debug(f"read {_id} ")
 
-
     def delete_by_id(self, _id: str) -> bool:
         """See :func:`DBConnector.delete_by_id`"""
         log.debug(f"delete {_id}")
-
 
     def select(
         self,

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -69,6 +69,30 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
+    def _flatten_meta(self, meta):
+
+        def _rec_flatten_meta(meta, flat_meta):
+            for col_name, col_data in meta["sub_scheme"].items():
+                types = col_data["types"]
+
+                if "Dict" in types:
+                    print(f"FOUND DICT: {col_name}" )
+                    _rec_flatten_meta(col_data, flat_meta)
+                else:
+                    if "sub_scheme" not in flat_meta:
+                        flat_meta["sub_scheme"] = {}
+                    flat_meta["sub_scheme"][col_name] = col_data
+            
+            return flat_meta
+
+        flat_meta = {}
+        for coll_name, coll_meta in meta.items():    
+            flat_meta[coll_name] = {}
+            print(f"PARSE {coll_name}")
+            _rec_flatten_meta(coll_meta, flat_meta[coll_name])
+
+        return flat_meta
+
     def _to_sql_type(self, str_type):
         return {"String": "TEXT", "Bool": "INTEGER", "Ref": "TEXT"}[str_type]
 
@@ -312,6 +336,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                     col_data = self._many_many_table_structure(col_name, col_data)
                     for dst_id in o[col_name]:
                         table_data = col_data["join_table"]
+                        # Note that here we can insert multiple rows in single operation (more effective)
                         str_request = f"INSERT INTO {table_data['name']} ({col_data['col_name']}, {col_data['rev_col_name']}) VALUES ('{dst_id}', '{_id}')"
                         log.debug(f"Execute: {str_request}")
                         self._cursor.execute(str_request)
@@ -366,11 +391,11 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 col_types = col_data["data"]["types"]
                 table_data = col_data["join_table"]
                 str_request = f"SELECT join_table.{col_data['col_name']} FROM {table_data['name']} join_table INNER JOIN {self._collection_name} cur ON cur._id = join_table.{col_data['rev_col_name']} WHERE cur._id = '{_id}'"
+                log.debug(f"Execute: {str_request}")
                 self._cursor.execute(str_request)
                 o[col_data["col_name"]] = [
                     self._map_val(row[0], col_types) for row in self._cursor.fetchall()
                 ]
-                print(str_request)
 
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -162,14 +162,27 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             str_request = f"DELETE FROM {self._collection_name}"
             log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request)
+            # self._con.commit()
+
+            # Delete many-many relationships in intermediate table
+            for col_name, col_data in self._scheme.items():
+                if self._is_many_many_relationship(col_data):
+                    table_name, _, _, _, _ = self._many_many_table_structure(
+                        col_name, col_data
+                    )
+
+                    str_request = f"DELETE FROM {table_name}"
+                    log.debug(f"Execute: {str_request}")
+                    self._cursor.execute(str_request)
+
             self._con.commit()
 
             # Check how many rows were deleted
             deleted_rows = self._cursor.rowcount
-            print(f"✓ Deleted {deleted_rows} row(s)")
+            log.debug(f"✓ Deleted {deleted_rows} row(s)")
 
             if deleted_rows == 0:
-                print("⚠ Warning: No rows matched the condition")
+                log.warning("No rows matched the condition")
 
         self._sqlite_try(delete_all)
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -11,6 +11,7 @@ import sqlite3
 sys.path.insert(1, "../../stricto")
 
 from stricto import Kparse
+from .api_toolbox import append_path_to_filter
 
 from .db_connector import DBConnector
 from .error import NotFoundError
@@ -70,6 +71,33 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
+    def get_at_path(self, path, d: dict):
+        clean_path = path[2:]
+        chunks = clean_path.split('.')
+        v = d
+        for c in chunks:
+            if c in v:
+                v = v[c]
+            else:
+                return None
+        
+        return v
+
+    def set_at_path(self, path, d: dict, value):
+        clean_path = path[2:]
+        chunks = clean_path.split('.')
+        v = d
+        
+        # Navigate to the parent of the target key
+        for c in chunks[:-1]:
+            if c not in v:
+                v[c] = {}
+            v = v[c]
+        
+        # Set the value at the final key
+        if chunks:
+            v[chunks[-1]] = value
+
     def _flatten_meta(self, meta):
 
         def _rec_flatten_meta(meta, flat_meta):
@@ -81,7 +109,9 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                 else:
                     if "sub_scheme" not in flat_meta:
                         flat_meta["sub_scheme"] = {}
-                    flat_meta["sub_scheme"][col_name] = col_data
+                    # flat_meta["sub_scheme"][col_name] = col_data
+                    flat_meta["sub_scheme"][col_data["path"]] = col_data
+                    flat_meta["sub_scheme"][col_data["path"]]["name"] = col_name
             
             return flat_meta
 
@@ -95,6 +125,14 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
     def _to_sql_type(self, str_type):
         return {"String": "TEXT", "Bool": "INTEGER", "Int": "INTEGER", "Datetime": "INTEGER", "Ref": "TEXT"}[str_type]
 
+    def _json_path_to_sql_path(self, path):
+        # return path[2:].replace(".", "_")
+        # return path.replace("$", "\$").replace(".", "\.")
+        return path
+
+    def  _sql_path_to_json_path(self, path):
+        pass
+
     def _is_many_many_relationship(self, col_data):
         """
         Check whether given col is a many-many relationship
@@ -104,9 +142,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             return False
 
         rev_coll = col_data["collection"]
-        rev_col = col_data["reverse"][
-            2:
-        ]  # Tricky for now need to select actual field $.my.path.to
+        rev_col = col_data["reverse"]
         return "RefsList" in self._meta[rev_coll]["sub_scheme"][rev_col]["types"]
 
     def _get_many_many_cols(self):
@@ -119,7 +155,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             if self._is_many_many_relationship(col_data):
                 yield self._many_many_table_structure(col_name, col_data)
 
-    def _many_many_table_structure(self, col_name, col_data):
+    def _many_many_table_structure(self, col_path, col_data):
         """
         Generate name and column mapping for an intermediate many-to-many join table.
         """
@@ -128,8 +164,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         target_coll = col_data["collection"]
 
         # If it's a fixed prefix, consider using .lstrip() or .removeprefix() instead of slicing
-        target_col_name = col_data["reverse"][2:]
-        source_col_name = col_name
+        target_col_name = col_data["reverse"]
+        source_col_name = col_path
 
         # 2. Determine a deterministic order so TableA->TableB and TableB->TableA resolve identically
         # We pack the related entities into standardized pairs
@@ -140,10 +176,11 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         first_side, second_side = sorted([sources, targets], key=lambda x: x[0])
 
         # 3. Construct the table name cleanly
-        table_name = f"{first_side[0]}_{first_side[1]}_{second_side[0]}"
+        col = first_side[1].replace("$.", "").replace(".", "_")
+        table_name = f"{first_side[0]}_{col}_{second_side[0]}"
 
         return {
-            "col_name": col_name,
+            "col_name": col_path,
             "data": col_data,
             "rev_col_name": target_col_name,
             "join_table": {
@@ -171,11 +208,11 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         table_data = col_data["join_table"]
         return f"""
         CREATE TABLE IF NOT EXISTS {table_data['name']} (
-            {table_data['source_col']} TEXT ,
-            {table_data['target_col']} TEXT ,
-            FOREIGN KEY ({table_data['source_col']}) REFERENCES {table_data['source_coll']}(_id) ,
-            FOREIGN KEY ({table_data['target_col']}) REFERENCES {table_data['target_coll']}(_id) ,
-            PRIMARY KEY ({table_data['source_col']}, {table_data['target_col']})
+            '{table_data['source_col']}' TEXT ,
+            '{table_data['target_col']}' TEXT ,
+            FOREIGN KEY ('{table_data['source_col']}') REFERENCES {table_data['source_coll']}(_id) ,
+            FOREIGN KEY ('{table_data['target_col']}') REFERENCES {table_data['target_coll']}(_id) ,
+            PRIMARY KEY ('{table_data['source_col']}', '{table_data['target_col']}')
         );
         """
 
@@ -187,15 +224,16 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         for col_name, col_data in self._scheme.items():
             col_type = col_data["types"][0]
-            if not col_name.startswith("_") and not col_type == "RefsList":
-                str_cols.append(f"{col_name} {self._to_sql_type(col_type)}")
+            if not col_type == "RefsList":
+                str_cols.append(f"'{col_data["path"]}' {self._to_sql_type(col_type)}")
 
         # Add one-many relationship
         for col_name, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if col_type == "Ref":
                 str_cols.append(
-                    f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)"
+                    # f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)"
+                    f"FOREIGN KEY ('{col_data["path"]}') REFERENCES {col_data["collection"]}(_id)"
                 )
 
         str_request = f"""
@@ -315,14 +353,17 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def insert():
 
-            t = []
+            col_value_pairs = []
             for col_name, col_data in self._scheme.items():
-                # Exclude RefsList and _meta columns for insert
-                if "RefsList" not in col_data["types"] and col_name != "_meta" and col_name in o:
-                    t.append((col_name, self._format_val(o[col_name])))
+                path = col_data["path"]
+                val = self.get_at_path(path, o)
+                print(f"GET {col_name}, path {path}: {val}")
+                # Exclude RefsList for insert
+                if val is not None and "RefsList" not in col_data["types"]:
+                    col_value_pairs.append((path, self._format_val(val)))
 
-            str_col_names = ",".join(field_name for field_name, _ in t)
-            str_values = ",".join(field_value for _, field_value in t)
+            str_col_names = ",".join(f"'{field_name}'" for field_name, _ in col_value_pairs)
+            str_values = ",".join(field_value for _, field_value in col_value_pairs)
 
             str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({str_values})"
 
@@ -331,15 +372,18 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             self._cursor.execute(str_request)
 
             # Insert many-many relationships in intermediate table
-            for col_name, col_data in self._scheme.items():
+            for col_path, col_data in self._scheme.items():
                 if self._is_many_many_relationship(col_data):
-                    col_data = self._many_many_table_structure(col_name, col_data)
-                    for dst_id in o[col_name]:
-                        table_data = col_data["join_table"]
-                        # Note that here we can insert multiple rows in single operation (more effective)
-                        str_request = f"INSERT INTO {table_data['name']} ({col_data['col_name']}, {col_data['rev_col_name']}) VALUES ('{dst_id}', '{_id}')"
-                        log.debug(f"Execute: {str_request}")
-                        self._cursor.execute(str_request)
+                    print(f"COL IS MANY MANY ? : {col_path}")
+                    col_data = self._many_many_table_structure(col_path, col_data)
+                    val = self.get_at_path(col_path, o)
+                    if val is not None:
+                        for dst_id in val:
+                            table_data = col_data["join_table"]
+                            # Note that here we can insert multiple rows in single operation (more effective)
+                            str_request = f"INSERT INTO {table_data['name']} ('{col_path}', '{col_data['rev_col_name']}') VALUES ('{dst_id}', '{_id}')"
+                            log.debug(f"Execute: {str_request}")
+                            self._cursor.execute(str_request)
 
             # Commit all requests
             self._con.commit()
@@ -368,7 +412,7 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def select():
             # Create and execute request
-            str_request = f"SELECT * FROM {self._collection_name} WHERE _id='{_id}'"
+            str_request = f"SELECT * FROM {self._collection_name} WHERE \"$._id\"='{_id}'"
             log.debug(f"Execute: {str_request}")
             self._cursor.execute(str_request)
             row = self._cursor.fetchone()
@@ -388,12 +432,30 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             for col_data in self._get_many_many_cols():
                 col_types = col_data["data"]["types"]
                 table_data = col_data["join_table"]
-                str_request = f"SELECT join_table.{col_data['col_name']} FROM {table_data['name']} join_table INNER JOIN {self._collection_name} cur ON cur._id = join_table.{col_data['rev_col_name']} WHERE cur._id = '{_id}'"
+                str_request = f"SELECT join_table.\"{col_data['col_name']}\" FROM {table_data['name']} join_table INNER JOIN {self._collection_name} cur ON cur.\"$._id\" = join_table.\"{col_data['rev_col_name']}\" WHERE cur.\"$._id\" = '{_id}'"
                 log.debug(f"Execute: {str_request}")
                 self._cursor.execute(str_request)
-                o[col_data["col_name"]] = [
-                    self._map_val(row[0], col_types) for row in self._cursor.fetchall()
-                ]
+                
+                col_path = col_data["col_name"]
+                # x = self.get_at_path(col_path, o)
+                # if "is_loved_by" in o:
+                #     print("IS LOVEEE: " + o["is_loved_by"])
+
+
+                self.set_at_path(col_path, o, [
+                    self._map_val(row[col_path], col_types) for row in self._cursor.fetchall()
+                ])
+
+                # append_path_to_filter(o, col_path[2:], [
+                #     self._map_val(row[col_path], col_types) for row in self._cursor.fetchall()
+                # ])
+
+                # o[col_data["col_name"]] = [
+                #     self._map_val(row[0], col_types) for row in self._cursor.fetchall()
+                # ]
+
+
+
 
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 

--- a/backo/db_sql_connector.py
+++ b/backo/db_sql_connector.py
@@ -11,6 +11,7 @@ import sqlite3
 sys.path.insert(1, "../../stricto")
 
 from stricto import Kparse
+# from .api_toolbox import append_path_to_filter
 
 from .db_connector import DBConnector
 from .error import NotFoundError
@@ -37,6 +38,21 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
 
     """
+
+    # Note: just for test,
+    # must use prepared queries to avoid this !
+    def _escape_sql_string(self, s):
+        """Escape SQL special characters using translation table"""
+        trans_table = str.maketrans({
+            "'": "''",
+            '"': '""',
+            "\\": "\\\\",
+            "\0": "\\0",
+            "\n": "\\n",
+            "\r": "\\r",
+            "\x1a": "\\Z",
+        })
+        return s.translate(trans_table)
 
     def __init__(self, **kwargs):
         """constructor"""
@@ -71,6 +87,10 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
 
     def get_at_path(self, path, d: dict):
+        """
+        Get value of a dict at given JSON path
+        Note: Just a simple implementation to quick test, but does not support array !
+        """
         clean_path = path[2:]
         chunks = clean_path.split(".")
         v = d
@@ -83,6 +103,10 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         return v
 
     def set_at_path(self, path, d: dict, value):
+        """
+        Set value of a dict at given JSON path
+        Note: Just a simple implementation to quick test, but does not support array !
+        """
         clean_path = path[2:]
         chunks = clean_path.split(".")
         v = d
@@ -98,7 +122,10 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             v[chunks[-1]] = value
 
     def _flatten_meta(self, meta):
-
+        """
+        Flatten metadata to get all nested fields at the same level,
+        key becomes the field path instead of field name
+        """
         def _rec_flatten_meta(meta, flat_meta):
             for col_name, col_data in meta["sub_scheme"].items():
                 types = col_data["types"]
@@ -121,22 +148,19 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         return flat_meta
 
-    def _to_sql_type(self, str_type):
+    def _to_sql_type(self, str_type : str) -> str:
+        """
+        Convert stricto type (string) to SQL type
+        Note: Non exhaustive !
+        """
         return {
             "String": "TEXT",
             "Bool": "INTEGER",
             "Int": "INTEGER",
+            "Float": "REAL",
             "Datetime": "INTEGER",
             "Ref": "TEXT",
         }[str_type]
-
-    def _json_path_to_sql_path(self, path):
-        # return path[2:].replace(".", "_")
-        # return path.replace("$", "\$").replace(".", "\.")
-        return path
-
-    def _sql_path_to_json_path(self, path):
-        pass
 
     def _is_many_many_relationship(self, col_data):
         """
@@ -201,13 +225,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         Generate the SQL query to create an intermediate join table for a
         many-to-many relationship.
-
-        Args:
-            table_structure (tuple): A 5-element tuple containing:
-                (table_name, source_coll, target_coll, source_col_name, target_col_name)
-
-        Returns:
-            str: A raw SQL 'CREATE TABLE' query string.
         """
         # Get data of intermediate table
         table_data = col_data["join_table"]
@@ -227,18 +244,18 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """
         str_cols = []
 
-        for col_name, col_data in self._scheme.items():
+        for col_path, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if not col_type == "RefsList":
-                str_cols.append(f"'{col_data["path"]}' {self._to_sql_type(col_type)}")
+                str_cols.append(f"'{col_path}' {self._to_sql_type(col_type)}")
 
         # Add one-many relationship
-        for col_name, col_data in self._scheme.items():
+        for col_path, col_data in self._scheme.items():
             col_type = col_data["types"][0]
             if col_type == "Ref":
                 str_cols.append(
                     # f"FOREIGN KEY ({col_name}) REFERENCES {col_data["collection"]}(_id)"
-                    f"FOREIGN KEY ('{col_data["path"]}') REFERENCES {col_data["collection"]}(_id)"
+                    f"FOREIGN KEY ('{col_path}') REFERENCES {col_data["collection"]}(_id)"
                 )
 
         str_request = f"""
@@ -303,26 +320,27 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         """See :func:`DBConnector.save`"""
         log.debug(f"save {_id} ")
 
-    def _format_val(self, val):
+    def _format_val(self, val) -> str:
+        """
+        Format value to SQL string according to its type
+        """
         if isinstance(val, bool):
             return "TRUE" if val else "FALSE"
         if isinstance(val, str):
-            return f"'{val}'"
+            return f"'{self._escape_sql_string(val)}'"
 
-        return val
+        return str(val)
 
     def _map_val(self, val, target_types):
-        print(val)
-        print(target_types)
+        """
+        Map a value according to given target type
+        """
         if "Bool" in target_types:
             return bool(val)
         if "Int" in target_types:
             return int(val)
 
         return val
-
-    def _is_internal_field(self, field):
-        return field.startswith("_")
 
     def _sqlite_try(self, callback):
         """
@@ -358,30 +376,29 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
 
         def insert():
 
-            col_value_pairs = []
-            for col_name, col_data in self._scheme.items():
-                path = col_data["path"]
-                val = self.get_at_path(path, o)
-                print(f"GET {col_name}, path {path}: {val}")
+            # Collect column names and values in a single pass
+            col_names = []
+            col_values = []
+
+            for col_path, col_data in self._scheme.items():
+                val = self.get_at_path(col_path, o)
                 # Exclude RefsList for insert
                 if val is not None and "RefsList" not in col_data["types"]:
-                    col_value_pairs.append((path, self._format_val(val)))
+                    col_names.append(col_path)
+                    col_values.append(val)
 
-            str_col_names = ",".join(
-                f"'{field_name}'" for field_name, _ in col_value_pairs
-            )
-            str_values = ",".join(field_value for _, field_value in col_value_pairs)
+            # Build prepared query
+            str_col_names = ",".join(f'"{col_name}"' for col_name in col_names)
+            placeholders = ",".join("?" * len(col_values))
+            str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({placeholders})"
 
-            str_request = f"INSERT INTO {self._collection_name} ({str_col_names}) VALUES ({str_values})"
-
-            # Insert
+            # Execute with values passed separately
             log.debug(f"Execute: {str_request}")
-            self._cursor.execute(str_request)
+            self._cursor.execute(str_request, col_values)
 
             # Insert many-many relationships in intermediate table
             for col_path, col_data in self._scheme.items():
                 if self._is_many_many_relationship(col_data):
-                    print(f"COL IS MANY MANY ? : {col_path}")
                     col_data = self._many_many_table_structure(col_path, col_data)
                     val = self.get_at_path(col_path, o)
                     if val is not None:
@@ -408,8 +425,12 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         for col_name, col_data in self._scheme.items():
             col_types = col_data["types"]
 
-            if col_name in row and "RefsList" not in col_types:
-                o[col_name] = self._map_val(row[col_name], col_types)
+            row_dict = dict(row)
+            if col_name in row_dict and "RefsList" not in col_types:
+                val = row[col_name]
+                if val:
+                    map_val = self._map_val(row[col_name], col_types)
+                    self.set_at_path(col_name, o, map_val)
 
         return o
 
@@ -418,13 +439,14 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
         log.debug(f"read {_id} ")
 
         def select():
-            # Create and execute request
+            # Create and execute request using prepared query
             str_request = (
-                f"SELECT * FROM {self._collection_name} WHERE \"$._id\"='{_id}'"
+                f"SELECT * FROM {self._collection_name} WHERE \"$._id\"=?"
             )
             log.debug(f"Execute: {str_request}")
-            self._cursor.execute(str_request)
+            self._cursor.execute(str_request, (_id,))
             row = self._cursor.fetchone()
+
 
             # No results !
             if row is None:
@@ -434,6 +456,8 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                     self._collection_name,
                 )
 
+
+
             # Map row result to object
             o = self._map_row(row)
 
@@ -441,14 +465,16 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
             for col_data in self._get_many_many_cols():
                 col_types = col_data["data"]["types"]
                 table_data = col_data["join_table"]
-                str_request = f"SELECT join_table.\"{col_data['col_name']}\" FROM {table_data['name']} join_table INNER JOIN {self._collection_name} cur ON cur.\"$._id\" = join_table.\"{col_data['rev_col_name']}\" WHERE cur.\"$._id\" = '{_id}'"
+                str_request = f"SELECT join_table.\"{col_data['col_name']}\" \
+                    FROM {table_data['name']} join_table \
+                    INNER JOIN {self._collection_name} cur \
+                    ON cur.\"$._id\" = join_table.\"{col_data['rev_col_name']}\" \
+                    WHERE cur.\"$._id\" = '{_id}'"
+
                 log.debug(f"Execute: {str_request}")
                 self._cursor.execute(str_request)
 
                 col_path = col_data["col_name"]
-                # x = self.get_at_path(col_path, o)
-                # if "is_loved_by" in o:
-                #     print("IS LOVEEE: " + o["is_loved_by"])
 
                 self.set_at_path(
                     col_path,
@@ -458,14 +484,6 @@ class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attribut
                         for row in self._cursor.fetchall()
                     ],
                 )
-
-                # append_path_to_filter(o, col_path[2:], [
-                #     self._map_val(row[col_path], col_types) for row in self._cursor.fetchall()
-                # ])
-
-                # o[col_data["col_name"]] = [
-                #     self._map_val(row[0], col_types) for row in self._cursor.fetchall()
-                # ]
 
             log.debug(f"✓ GetById {self._collection_name} {_id}")
 

--- a/backo/db_sqlite_connector.py
+++ b/backo/db_sqlite_connector.py
@@ -29,7 +29,7 @@ KPARSE_MODEL = {
 log = log_system.get_or_create_logger("test")
 
 
-class DBSQLConnector(DBConnector):  # pylint: disable=too-many-instance-attributes
+class DBSQLiteConnector(DBConnector):  # pylint: disable=too-many-instance-attributes
     """Test SQL Connector
 
     This is the way to save / store / retrieve objects in yaml files

--- a/backo/db_sqlite_connector.py
+++ b/backo/db_sqlite_connector.py
@@ -63,7 +63,9 @@ class DBSQLiteConnector(DBConnector):  # pylint: disable=too-many-instance-attri
 
         try:
             self._con = sqlite3.connect(f"{self._path}/{self._dbname}.db")
-            self._con.row_factory = sqlite3.Row # Enable to get a column indexed by name
+            self._con.row_factory = (
+                sqlite3.Row
+            )  # Enable to get a column indexed by name
             self._cursor = self._con.cursor()
         except Exception as e:
             raise DBError('SQLLite connection error at "{0}"', self._path) from e
@@ -585,7 +587,7 @@ class DBSQLiteConnector(DBConnector):  # pylint: disable=too-many-instance-attri
         # Get cols that are not RefLists
         for col_name, col_data in self._scheme.items():
             col_types = col_data["types"]
-            row_dict = dict(row) # Need to convert to dict (for indexation)
+            row_dict = dict(row)  # Need to convert to dict (for indexation)
             if col_name in row_dict and "RefsList" not in col_types:
                 val = row[col_name]
                 if val:

--- a/backo/ref.py
+++ b/backo/ref.py
@@ -133,7 +133,7 @@ class Ref(String):  # pylint: disable=too-many-instance-attributes
         :return: the schema
         :rtype: dict
         """
-        a = super().self.get_schema()
+        a = super().get_schema()
         a["collection"] = self._collection
         a["reverse"] = self._reverse
         return a

--- a/backo/refslist.py
+++ b/backo/refslist.py
@@ -171,7 +171,7 @@ class RefsList(List):
         :return: the schema
         :rtype: dict
         """
-        a = super().self.get_schema()
+        a = super().get_schema()
         a["collection"] = self._collection
         a["reverse"] = self._reverse
         return a

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,7 @@ sys.path.insert(1, "../stricto")
 from .test_crud import TestCRUD
 from .test_log import TestLog
 
-from .test_mongo import TestMongo
+# from .test_mongo import TestMongo
 from .test_action import TestAction
 from .test_routes import TestRoutes
 from .test_reference import TestReferences

--- a/tests/test_api_toolbox.py
+++ b/tests/test_api_toolbox.py
@@ -8,7 +8,7 @@ import unittest
 
 
 from werkzeug.datastructures import ImmutableMultiDict
-from backo import multidict_to_filter
+from backo import multidict_to_filter, append_path_to_filter, flatter, unflatter
 
 
 class TestApiToolbox(unittest.TestCase):
@@ -55,3 +55,52 @@ class TestApiToolbox(unittest.TestCase):
         self.assertEqual(my_filter["a"], 1)
         self.assertEqual(my_filter["toto"], ("$gt", 1))
         self.assertEqual(my_filter["b"]["c"], ("$re", "in"))
+
+    def test_append_path_to_filter(self):
+        """
+        test_append_path_to_filter
+        """
+        o = {}
+        append_path_to_filter(o, "name", "zaza")
+        self.assertEqual(o["name"], "zaza")
+        append_path_to_filter(o, "sub.aa", "zaza")
+        self.assertEqual(o["sub"]["aa"], "zaza")
+        append_path_to_filter(o, "sub.bb", "zozo")
+        self.assertEqual(o["sub"]["bb"], "zozo")
+        append_path_to_filter(o, "sec", ["sec_0"])
+
+    def test_flat(self):
+        """
+        test_append_path_to_filter
+        """
+        o = {
+            "name": "a",
+            "loc": {"a": 1, "b": 2},
+            "c": [1, 2],
+            "d": [{"i": 1, "j": {"k": 2}}, {"i": 11, "j": {"k": 22}}],
+        }
+        f = {}
+        flatter(f, o)
+        self.assertEqual(
+            str(f),
+            "{'name': 'a', 'loc.a': 1, 'loc.b': 2, 'c': [1, 2], 'd': [{'i': 1, 'j.k': 2}, {'i': 11, 'j.k': 22}]}",
+        )
+
+    def test_unflat(self):
+        """
+        test_append_path_to_filter
+        """
+        o = {
+            "name": "a",
+            "loc.a": 1,
+            "loc.b": 2,
+            "c": [1, 2],
+            "d": [{"i": 1, "j.k": 2}, {"i": 11, "j.k": 22}],
+        }
+        f = {}
+        for k, v in o.items():
+            unflatter(f, k.split("."), v)
+        self.assertEqual(
+            str(f),
+            "{'name': 'a', 'loc': {'b': 2}, 'c': [1, 2], 'j.k': [{'i': 1, 'j': {'k': 2}}, {'i': 11, 'j': {'k': 22}}]}",
+        )

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -54,10 +54,10 @@ class TestMongo(unittest.TestCase):
         print(json.dumps(self._animal_meta, indent=4))
 
         # --- DB for user
-        self.db_users = DBSQLConnector(collection="Users", path="sqlite_test_db", meta=self._user_meta)
+        self.db_users = DBSQLConnector(collection="Users", path="sqlite_test_db", meta=self._meta)
 
         # --- DB for sites
-        self.db_animals = DBSQLConnector(collection="Animals", path="sqlite_test_db", meta=self._animal_meta)
+        self.db_animals = DBSQLConnector(collection="Animals", path="sqlite_test_db", meta=self._meta)
 
         self._backoffice.register_collection(
             Collection(

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -5,13 +5,21 @@ test for CRUD()
 # pylint: disable=wrong-import-position, no-member, import-error, protected-access, wrong-import-order, duplicate-code
 
 import unittest
-import json
+# import json
 
 from backo import Item, Collection
 from backo import DBSQLConnector
 from backo import Backoffice, current_user
 
-from backo import String, Bool, Int, Ref, RefsList, Dict  # , Error as StrictoError
+from backo import (
+    String,
+    Bool,
+    Int,
+    Float,
+    Ref,
+    RefsList,
+    Dict,
+)  # , Error as StrictoError
 
 from backo import log_system, LogLevel
 
@@ -21,9 +29,9 @@ log = log_system.get_or_create_logger("testing")
 log_system.setLevel(LogLevel.DEBUG)
 
 
-class TestMongo(unittest.TestCase):
+class TestSQLiteConnector(unittest.TestCase):
     """
-    DB SQL crud
+    DB SQLite crud
     """
 
     def __init__(self, *args, **kwargs):
@@ -42,7 +50,14 @@ class TestMongo(unittest.TestCase):
                 "animals": RefsList(coll="animals", field="$.user"),
                 "is_loved_by": RefsList(coll="animals", field="$.love"),
                 "location": Dict(
-                    {"country": String(), "city": String(), "postal_code": Int()}
+                    {
+                        "country": String(),
+                        "city": String(),
+                        "city_info": Dict(
+                            {"postal_code": Int(), "gps_coord_x": Float()}
+                        ),
+                        "postal_code": Int(),
+                    }
                 ),
             }
         )
@@ -56,23 +71,39 @@ class TestMongo(unittest.TestCase):
             }
         )
 
+        types_item = Item({"s": String(), "i": Int(), "b": Bool(), "f": Float()})
+
         self._meta = {}
         self._meta["users"] = user_item.get_schema()
         self._meta["animals"] = animal_item.get_schema()
+        self._meta["types"] = types_item.get_schema()
 
-        print(json.dumps(self._meta, indent=4))
+        # print(json.dumps(self._meta, indent=4))
 
         # --- DB for user
         self.db_users = DBSQLConnector(
             collection="users", path="sqlite_test_db", meta=self._meta
         )
 
-        # --- DB for sites
+        # --- DB for animals
         self.db_animals = DBSQLConnector(
             collection="animals", path="sqlite_test_db", meta=self._meta
         )
 
-        print(json.dumps(self.db_users._flatten_meta(self._meta), indent=4))
+        # --- DB for types
+        self.db_types = DBSQLConnector(
+            collection="types", path="sqlite_test_db", meta=self._meta
+        )
+
+        # print(json.dumps(self.db_users._flatten_meta(self._meta), indent=4))
+
+        self._backoffice.register_collection(
+            Collection(
+                "types",
+                types_item,
+                self.db_types,
+            )
+        )
 
         self._backoffice.register_collection(
             Collection(
@@ -101,75 +132,61 @@ class TestMongo(unittest.TestCase):
         self.db_users.close()
         return super().tearDown()
 
-    # def test_db_connect(self):
-    #     """
-    #     try to connect
-    #     """
 
-    #     self.db_users.create_table()
-    #     self.db_animals.create_table()
-    #     self.db_users.drop()
-    #     self.db_animals.drop()
+    def test_none_values(self):
+        """
+        Test CRUD on None values
+        """
+        self.db_types.create_table()
+        self.db_types.drop()
 
-    #     u0 = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
-    #     u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
-    #     u2 = self._backoffice.users.create(
-    #         {"name": "benji", "surname": "benjie", "male": False}
-    #     )
+        log.debug("Test None values")
 
-    #     # u0_ = backoffice.users.new()
-    #     # u0_.load(u0._id)
-    #     # print(u0_)
-    #     # u1_ = backoffice.users.new()
-    #     # u1_.load(u1._id)
-    #     # print(u1_)
-    #     # u2_ = backoffice.users.new()
-    #     # u2_.load(u2._id)
-    #     # print(u2_)
+        types = self._backoffice.types.create({"s": "hello"})
 
-    #     a0 = self._backoffice.animals.create(
-    #         {
-    #             "surname": "cookie",
-    #             "type": "dog",
-    #             "user": u0._id,
-    #             "love": [u0._id, u1._id, u2._id],
-    #         }
-    #     )
-    #     a1 = self._backoffice.animals.create(
-    #         {"surname": "pioo", "type": "bird", "user": u0._id, "love": [u0._id]}
-    #     )
+        loaded_types = self._backoffice.types.new()
+        loaded_types.load(types._id)
 
-    #     u3 = self._backoffice.users.create(
-    #         {"name": "jean", "surname": "valjean", "is_loved_by": [a1._id]}
-    #     )
+        self.assertEqual(types.s, loaded_types.s)
+        self.assertEqual(loaded_types.i, None)
+        self.assertEqual(loaded_types.b, None)
+        self.assertEqual(loaded_types.f, None)
 
-    #     print("RELOAD !!!!")
-    #     # a1.reload()
-    #     b = self._backoffice.animals.new()
-    #     b.load(a1._id)
+    def test_types(self):
+        """
+        Test CRUD on different stricto types
+        """
+        self.db_types.create_table()
+        self.db_types.drop()
 
-    #     print(a0.select("$.user.name"))
-    #     print(a1.select("$.user.name"))
+        log.debug("Test support of object creation with different types")
 
-    #     print(f"{a0['surname']} loves ")
-    #     print(a0.select("$.love.name"))
+        types = self._backoffice.types.create(
+            {"s": "hello", "i": 42, "b": True, "f": 42.42}
+        )
 
-    #     print(f"{b['surname']} loves ")
-    #     print(b.select("$.love.name"))
-    #     print(f"{u3['surname']} is loved by ")
-    #     print(f"{u3.select("$.is_loved_by.surname")}")
+        types2 = self._backoffice.types.new()
+        types2.load(types._id)
 
-    #     # x_ = backoffice.users.new()
-    #     # x_.load("plop")
-
-    def test_one_to_many(self):
-        pass
+        self.assertEqual(types.s, types2.s)
+        self.assertEqual(types.i, types2.i)
+        self.assertEqual(types.b, types2.b)
+        self.assertEqual(types.f, types2.f)
 
     def test_nested(self):
+        """
+        Test CRUD on nested fields
+        """
         self.db_users.create_table()
         self.db_animals.create_table()
+        self.db_types.create_table()
+
         self.db_users.drop()
         self.db_animals.drop()
+        self.db_types.drop()
+
+        log.debug("Test nested - one level")
+
         bebert = self._backoffice.users.create(
             {
                 "name": "bebert",
@@ -178,14 +195,43 @@ class TestMongo(unittest.TestCase):
             }
         )
 
+        bebert2 = self._backoffice.users.new()
+        bebert2.load(bebert._id)
+
+        self.assertEqual(bebert.location.city, bebert2.location.city)
+        self.assertEqual(bebert.location.country, bebert2.location.country)
+
+        log.debug("Test nested - n levels")
+
+        joe = self._backoffice.users.create(
+            {
+                "name": "joe",
+                "surname": "joe l'embrouille",
+                "location": {"city_info": {"postal_code": 54, "gps_coord_x": 23.54345}},
+            }
+        )
+        joe2 = self._backoffice.users.new()
+        joe2.load(joe._id)
+
+        self.assertEqual(joe.location.city_info.postal_code, 54)
+        self.assertEqual(joe.location.city_info.gps_coord_x, 23.54345)
+
+    def test_one_to_many(self):
+        """
+        Test one to many relationship
+        """
+
     def test_many_to_many(self):
         """
         Test many to many relationship
         """
         self.db_users.create_table()
         self.db_animals.create_table()
+        self.db_types.create_table()
+
         self.db_users.drop()
         self.db_animals.drop()
+        self.db_types.drop()
 
         bebert = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
         jean = self._backoffice.users.create({"name": "jean", "surname": "valjean"})
@@ -201,17 +247,6 @@ class TestMongo(unittest.TestCase):
                 "love": [bebert._id, jean._id],
             }
         )
-
-        # log.debug("# Create pioupiou")
-
-        # pioupiou = self._backoffice.animals.create(
-        #     {
-        #         "surname": "pioupiou",
-        #         "type": "bird",
-        #         "user": ted._id,
-        #         "love": [ted._id, jean._id],
-        #     }
-        # )
 
         log.debug("# Create benji")
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -5,7 +5,7 @@ test for CRUD()
 # pylint: disable=wrong-import-position, no-member, import-error, protected-access, wrong-import-order, duplicate-code
 
 import unittest
-
+import json
 
 from backo import Item, Collection
 from backo import DBSQLConnector
@@ -42,13 +42,17 @@ class TestMongo(unittest.TestCase):
         """
 
         backoffice = Backoffice("myApp")
+        user_item = Item(
+            {"name": String(), "surname": String(), "male": Bool(default=True)}
+        )
+
+        meta = user_item.get_schema()
+        print(meta)
 
         backoffice.register_collection(
             Collection(
                 "users",
-                Item(
-                    {"name": String(), "surname": String(), "male": Bool(default=True)}
-                ),
+                user_item,
                 self.db_users,
             )
         )
@@ -59,12 +63,23 @@ class TestMongo(unittest.TestCase):
         current_user.login = "Roger"
         current_user._id = "1234"
 
-        # print(json.dumps(backoffice.users.get_meta(), indent=4))
-        self.db_users.create_table(backoffice.users.get_meta())
-        # self.db_users.drop()
+        print(json.dumps(meta, indent=4))
+        self.db_users.create_table(meta)
+        self.db_users.drop()
 
-        # u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        v = backoffice.users.create({"name": "ted", "surname": "teddy"})
+        w = backoffice.users.create(
+            {"name": "benji", "surname": "benjie", "male": False}
+        )
         # print(u.name)
         # u.name = "bobi"
-        # v = backoffice.users.new()
-        # v.load(u._id)
+        u_ = backoffice.users.new()
+        u_.load(u._id)
+        print(u_)
+        v_ = backoffice.users.new()
+        v_.load(v._id)
+        print(v_)
+        w_ = backoffice.users.new()
+        w_.load(w._id)
+        print(w_)

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -13,6 +13,13 @@ from backo import Backoffice, current_user
 
 from backo import String, Bool, Ref, RefsList  # , Error as StrictoError
 
+from backo import log_system, LogLevel
+
+### --- For development ---
+log_system.add_handler(log_system.set_streamhandler())
+log = log_system.get_or_create_logger("testing")
+log_system.setLevel(LogLevel.DEBUG)
+
 
 class TestMongo(unittest.TestCase):
     """
@@ -127,8 +134,80 @@ class TestMongo(unittest.TestCase):
             {"surname": "pioo", "type": "bird", "user": u0._id, "love": [u0._id]}
         )
 
+        u3 = self._backoffice.users.create(
+            {"name": "jean", "surname": "valjean", "is_loved_by": [a1._id]}
+        )
+
+        print("RELOAD !!!!")
+        # a1.reload()
+        b = self._backoffice.animals.new()
+        b.load(a1._id)
+
         print(a0.select("$.user.name"))
         print(a1.select("$.user.name"))
 
+        print(f"{a0['surname']} loves ")
+        print(a0.select("$.love.name"))
+
+        print(f"{b['surname']} loves ")
+        print(b.select("$.love.name"))
+        print(f"{u3['surname']} is loved by ")
+        print(f"{u3.select("$.is_loved_by.surname")}")
+
         # x_ = backoffice.users.new()
         # x_.load("plop")
+
+    def test_many_to_many(self):
+        """
+        Test many to many relationship
+        """
+        self.db_users.create_table()
+        self.db_animals.create_table()
+        self.db_users.drop()
+        self.db_animals.drop()
+
+        bebert = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        jean = self._backoffice.users.create({"name": "jean", "surname": "valjean"})
+        # ted = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
+
+        log.debug("# Create cookie")
+
+        cookie = self._backoffice.animals.create(
+            {
+                "surname": "cookie",
+                "type": "dog",
+                "user": bebert._id,
+                "love": [bebert._id, jean._id],
+            }
+        )
+
+        # log.debug("# Create pioupiou")
+
+        # pioupiou = self._backoffice.animals.create(
+        #     {
+        #         "surname": "pioupiou",
+        #         "type": "bird",
+        #         "user": ted._id,
+        #         "love": [ted._id, jean._id],
+        #     }
+        # )
+
+        log.debug("# Create benji")
+
+        benji = self._backoffice.users.create(
+            {
+                "name": "benji",
+                "surname": "benjie",
+                "male": False,
+                "is_loved_by": [cookie._id],
+            }
+        )
+
+        self.assertEqual(len(cookie.love), 2)
+
+        log.debug("# Reload cookie")
+
+        cookie.reload()
+
+        self.assertEqual(len(cookie.love), 3)
+        self.assertEqual(len(benji.is_loved_by), 1)

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -74,7 +74,6 @@ class TestMongo(unittest.TestCase):
             collection="animals", path="sqlite_test_db", meta=self._meta
         )
 
-        print("3OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
         print(json.dumps(self.db_users._flatten_meta(self._meta), indent=4))
 
         self._backoffice.register_collection(
@@ -167,6 +166,14 @@ class TestMongo(unittest.TestCase):
 
     def test_one_to_many(self):
         pass
+
+    def test_nested(self):
+        self.db_users.create_table()
+        self.db_animals.create_table()
+        self.db_users.drop()
+        self.db_animals.drop()
+        bebert = self._backoffice.users.create({"name": "bebert", "surname": "bebert", "location": {"city": "pistache city", "country": "Pistachio"}})
+
 
     def test_many_to_many(self):
         """

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -100,10 +100,10 @@ class TestMongo(unittest.TestCase):
         self.db_animals.drop()
 
         u0 = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
-        # u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
-        # u2 = self._backoffice.users.create(
-        #     {"name": "benji", "surname": "benjie", "male": False}
-        # )
+        u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
+        u2 = self._backoffice.users.create(
+            {"name": "benji", "surname": "benjie", "male": False}
+        )
 
         # u0_ = backoffice.users.new()
         # u0_.load(u0._id)
@@ -116,10 +116,15 @@ class TestMongo(unittest.TestCase):
         # print(u2_)
 
         a0 = self._backoffice.animals.create(
-            {"surname": "cookie", "type": "dog", "user": u0._id}
+            {
+                "surname": "cookie",
+                "type": "dog",
+                "user": u0._id,
+                "love": [u0._id, u1._id, u2._id],
+            }
         )
         a1 = self._backoffice.animals.create(
-            {"surname": "pioo", "type": "bird", "user": u0._id}
+            {"surname": "pioo", "type": "bird", "user": u0._id, "love": [u0._id]}
         )
 
         print(a0.select("$.user.name"))

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -5,11 +5,13 @@ test for CRUD()
 # pylint: disable=wrong-import-position, no-member, import-error, protected-access, wrong-import-order, duplicate-code
 
 import unittest
+
 # import json
 
 from backo import Item, Collection
 from backo import DBSQLConnector
 from backo import Backoffice, current_user
+from backo import NotFoundError
 
 from backo import (
     String,
@@ -132,7 +134,6 @@ class TestSQLiteConnector(unittest.TestCase):
         self.db_users.close()
         return super().tearDown()
 
-
     def test_none_values(self):
         """
         Test CRUD on None values
@@ -215,6 +216,24 @@ class TestSQLiteConnector(unittest.TestCase):
 
         self.assertEqual(joe.location.city_info.postal_code, 54)
         self.assertEqual(joe.location.city_info.gps_coord_x, 23.54345)
+
+    def test_delete_by_id(self):
+        """
+        Test delete by id
+        """
+        self.db_users.create_table()
+        self.db_animals.create_table()
+        self.db_types.create_table()
+
+        self.db_users.drop()
+        self.db_animals.drop()
+        self.db_types.drop()
+
+        bebert = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        bebert.delete()
+        bebert2 = self._backoffice.users.new()
+
+        self.assertRaises(NotFoundError, lambda: bebert2.load(bebert._id))
 
     def test_one_to_many(self):
         """

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -9,7 +9,7 @@ import unittest
 # import json
 
 from backo import Item, Collection
-from backo import DBSQLConnector
+from backo import DBSQLiteConnector
 from backo import Backoffice, current_user
 from backo import NotFoundError
 
@@ -85,17 +85,17 @@ class TestSQLiteConnector(unittest.TestCase):
         # print(json.dumps(self._meta, indent=4))
 
         # --- DB for user
-        self.db_users = DBSQLConnector(
+        self.db_users = DBSQLiteConnector(
             collection="users", path="sqlite_test_db", meta=self._meta
         )
 
         # --- DB for animals
-        self.db_animals = DBSQLConnector(
+        self.db_animals = DBSQLiteConnector(
             collection="animals", path="sqlite_test_db", meta=self._meta
         )
 
         # --- DB for types
-        self.db_types = DBSQLConnector(
+        self.db_types = DBSQLiteConnector(
             collection="types", path="sqlite_test_db", meta=self._meta
         )
 

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -279,6 +279,7 @@ class TestSQLiteConnector(unittest.TestCase):
         self.assertIn(pioupiou._id, bebert.animals)
         self.assertIn(cookie._id, bebert.animals)
 
+
     def test_many_to_many(self):
         """
         Test many to many relationship

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -1,0 +1,77 @@
+"""
+test for CRUD()
+"""
+
+# pylint: disable=wrong-import-position, no-member, import-error, protected-access, wrong-import-order, duplicate-code
+
+import unittest
+import time
+import json
+
+
+from backo import Item, Collection
+from backo import DBSQLConnector
+from backo import Backoffice, NotFoundError, DBError, current_user
+
+from backo import String, Bool  # , Error as StrictoError
+
+
+class TestMongo(unittest.TestCase):
+    """
+    DB SQL crud
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        init this tests
+        """
+        super().__init__(*args, **kwargs)
+
+        # --- DB for user
+        self.db_users = DBSQLConnector(
+            collection="Users",
+            path="sqlite_test_db"
+        )
+
+        # --- DB for sites
+        self.db_site = DBSQLConnector(
+            collection="Sites",
+            path="sqlite_test_db"
+        )
+
+    def tearDown(self):
+        self.db_site.close()
+        self.db_users.close()
+        return super().tearDown()
+
+    def test_db_connect(self):
+        """
+        try to connect
+        """
+
+        backoffice = Backoffice("myApp")
+
+        backoffice.register_collection(
+            Collection(
+                "users",
+                Item(
+                    {"name": String(), "surname": String(), "male": Bool(default=True)}
+                ),
+                self.db_users
+            )
+        )
+        
+
+        # ignore sessions for this campaign of tests.
+        current_user.standalone = True
+
+        current_user.login = "Roger"
+        current_user._id = "1234"
+
+        # print(json.dumps(backoffice.users.get_meta(), indent=4))
+        self.db_users.create_table(backoffice.users.get_meta())
+        # u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        # v = backoffice.users.new()
+        # u.save()
+        # v.load(u._id)
+        self.db_users.drop()

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -25,23 +25,7 @@ class TestMongo(unittest.TestCase):
         """
         super().__init__(*args, **kwargs)
 
-        # --- DB for user
-        self.db_users = DBSQLConnector(collection="Users", path="sqlite_test_db")
-
-        # --- DB for sites
-        self.db_animals = DBSQLConnector(collection="Animals", path="sqlite_test_db")
-
-    def tearDown(self):
-        self.db_animals.close()
-        self.db_users.close()
-        return super().tearDown()
-
-    def test_db_connect(self):
-        """
-        try to connect
-        """
-
-        backoffice = Backoffice("myApp")
+        self._backoffice = Backoffice("myApp")
 
         user_item = Item(
             {
@@ -60,10 +44,22 @@ class TestMongo(unittest.TestCase):
             }
         )
 
-        user_meta = user_item.get_schema()
-        animal_meta = animal_item.get_schema()
+        self._meta = {}
+        self._meta["Users"] = user_item.get_schema()
+        self._meta["Animals"] = animal_item.get_schema()
+        self._user_meta = user_item.get_schema()
+        self._animal_meta = animal_item.get_schema()
 
-        backoffice.register_collection(
+        print(json.dumps(self._user_meta, indent=4))
+        print(json.dumps(self._animal_meta, indent=4))
+
+        # --- DB for user
+        self.db_users = DBSQLConnector(collection="Users", path="sqlite_test_db", meta=self._user_meta)
+
+        # --- DB for sites
+        self.db_animals = DBSQLConnector(collection="Animals", path="sqlite_test_db", meta=self._animal_meta)
+
+        self._backoffice.register_collection(
             Collection(
                 "users",
                 user_item,
@@ -71,7 +67,7 @@ class TestMongo(unittest.TestCase):
             )
         )
 
-        backoffice.register_collection(
+        self._backoffice.register_collection(
             Collection(
                 "animals",
                 animal_item,
@@ -85,16 +81,27 @@ class TestMongo(unittest.TestCase):
         current_user.login = "Roger"
         current_user._id = "1234"
 
-        print(json.dumps(user_meta, indent=4))
-        print(json.dumps(animal_meta, indent=4))
-        self.db_users.create_table(user_meta)
-        self.db_animals.create_table(animal_meta)
+    def tearDown(self):
+        self.db_animals.close()
+        self.db_users.close()
+        return super().tearDown()
+
+    def test_db_connect(self):
+        """
+        try to connect
+        """
+
+
+
+
+        self.db_users.create_table()
+        self.db_animals.create_table()
         self.db_users.drop()
         self.db_animals.drop()
 
-        u0 = backoffice.users.create({"name": "bebert", "surname": "bebert"})
-        u1 = backoffice.users.create({"name": "ted", "surname": "teddy"})
-        u2 = backoffice.users.create(
+        u0 = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
+        u2 = self._backoffice.users.create(
             {"name": "benji", "surname": "benjie", "male": False}
         )
 
@@ -108,9 +115,11 @@ class TestMongo(unittest.TestCase):
         # u2_.load(u2._id)
         # print(u2_)
 
-        print("CREATE!")
-        a0 = backoffice.animals.create({"surname": "cookie", "type": "dog", "user": u0._id})
-        print("CREATE!")
-        a1 = backoffice.animals.create({"surname": "pioo", "type": "bird", "user": u0._id})
+        a0 = self._backoffice.animals.create({"surname": "cookie", "type": "dog", "user": u0._id})
+        a1 = self._backoffice.animals.create({"surname": "pioo", "type": "bird", "user": u0._id})
+
+        
+        print(a0.select("$.user.name"))
+
         # x_ = backoffice.users.new()
         # x_.load("plop")

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -41,11 +41,9 @@ class TestMongo(unittest.TestCase):
                 "male": Bool(default=True),
                 "animals": RefsList(coll="animals", field="$.user"),
                 "is_loved_by": RefsList(coll="animals", field="$.love"),
-                "location": Dict({
-                    "country": String(),
-                    "city": String(),
-                    "postal_code": Int()
-                })
+                "location": Dict(
+                    {"country": String(), "city": String(), "postal_code": Int()}
+                ),
             }
         )
 
@@ -172,8 +170,13 @@ class TestMongo(unittest.TestCase):
         self.db_animals.create_table()
         self.db_users.drop()
         self.db_animals.drop()
-        bebert = self._backoffice.users.create({"name": "bebert", "surname": "bebert", "location": {"city": "pistache city", "country": "Pistachio"}})
-
+        bebert = self._backoffice.users.create(
+            {
+                "name": "bebert",
+                "surname": "bebert",
+                "location": {"city": "pistache city", "country": "Pistachio"},
+            }
+        )
 
     def test_many_to_many(self):
         """

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -11,7 +11,7 @@ from backo import Item, Collection
 from backo import DBSQLConnector
 from backo import Backoffice, current_user
 
-from backo import String, Bool  # , Error as StrictoError
+from backo import String, Bool, Ref, RefsList  # , Error as StrictoError
 
 
 class TestMongo(unittest.TestCase):
@@ -29,10 +29,10 @@ class TestMongo(unittest.TestCase):
         self.db_users = DBSQLConnector(collection="Users", path="sqlite_test_db")
 
         # --- DB for sites
-        self.db_site = DBSQLConnector(collection="Sites", path="sqlite_test_db")
+        self.db_animals = DBSQLConnector(collection="Animals", path="sqlite_test_db")
 
     def tearDown(self):
-        self.db_site.close()
+        self.db_animals.close()
         self.db_users.close()
         return super().tearDown()
 
@@ -42,12 +42,26 @@ class TestMongo(unittest.TestCase):
         """
 
         backoffice = Backoffice("myApp")
+
         user_item = Item(
-            {"name": String(), "surname": String(), "male": Bool(default=True)}
+            {
+                "name": String(),
+                "surname": String(),
+                "male": Bool(default=True),
+                "animals": RefsList(coll="animals", field="$.user"),
+            }
         )
 
-        meta = user_item.get_schema()
-        print(meta)
+        animal_item = Item(
+            {
+                "surname": String(),
+                "type": String(),
+                "user": Ref(coll="users", field="$.animals", required=True),
+            }
+        )
+
+        user_meta = user_item.get_schema()
+        animal_meta = animal_item.get_schema()
 
         backoffice.register_collection(
             Collection(
@@ -57,31 +71,46 @@ class TestMongo(unittest.TestCase):
             )
         )
 
+        backoffice.register_collection(
+            Collection(
+                "animals",
+                animal_item,
+                self.db_animals,
+            )
+        )
+
         # ignore sessions for this campaign of tests.
         current_user.standalone = True
 
         current_user.login = "Roger"
         current_user._id = "1234"
 
-        print(json.dumps(meta, indent=4))
-        self.db_users.create_table(meta)
+        print(json.dumps(user_meta, indent=4))
+        print(json.dumps(animal_meta, indent=4))
+        self.db_users.create_table(user_meta)
+        self.db_animals.create_table(animal_meta)
         self.db_users.drop()
+        self.db_animals.drop()
 
-        u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
-        v = backoffice.users.create({"name": "ted", "surname": "teddy"})
-        w = backoffice.users.create(
+        u0 = backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        u1 = backoffice.users.create({"name": "ted", "surname": "teddy"})
+        u2 = backoffice.users.create(
             {"name": "benji", "surname": "benjie", "male": False}
         )
-        # print(u.name)
-        # u.name = "bobi"
-        u_ = backoffice.users.new()
-        u_.load(u._id)
-        print(u_)
-        v_ = backoffice.users.new()
-        v_.load(v._id)
-        print(v_)
-        w_ = backoffice.users.new()
-        w_.load(w._id)
-        print(w_)
-        x_ = backoffice.users.new()
-        x_.load("plop")
+
+        # u0_ = backoffice.users.new()
+        # u0_.load(u0._id)
+        # print(u0_)
+        # u1_ = backoffice.users.new()
+        # u1_.load(u1._id)
+        # print(u1_)
+        # u2_ = backoffice.users.new()
+        # u2_.load(u2._id)
+        # print(u2_)
+
+        print("CREATE!")
+        a0 = backoffice.animals.create({"surname": "cookie", "type": "dog", "user": u0._id})
+        print("CREATE!")
+        a1 = backoffice.animals.create({"surname": "pioo", "type": "bird", "user": u0._id})
+        # x_ = backoffice.users.new()
+        # x_.load("plop")

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -279,7 +279,6 @@ class TestSQLiteConnector(unittest.TestCase):
         self.assertIn(pioupiou._id, bebert.animals)
         self.assertIn(cookie._id, bebert.animals)
 
-
     def test_many_to_many(self):
         """
         Test many to many relationship

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -11,7 +11,7 @@ from backo import Item, Collection
 from backo import DBSQLConnector
 from backo import Backoffice, current_user
 
-from backo import String, Bool, Ref, RefsList  # , Error as StrictoError
+from backo import String, Bool, Int, Ref, RefsList, Dict  # , Error as StrictoError
 
 from backo import log_system, LogLevel
 
@@ -41,6 +41,11 @@ class TestMongo(unittest.TestCase):
                 "male": Bool(default=True),
                 "animals": RefsList(coll="animals", field="$.user"),
                 "is_loved_by": RefsList(coll="animals", field="$.love"),
+                "location": Dict({
+                    "country": String(),
+                    "city": String(),
+                    "postal_code": Int()
+                })
             }
         )
 
@@ -69,6 +74,9 @@ class TestMongo(unittest.TestCase):
             collection="animals", path="sqlite_test_db", meta=self._meta
         )
 
+        print("3OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO")
+        print(json.dumps(self.db_users._flatten_meta(self._meta), indent=4))
+
         self._backoffice.register_collection(
             Collection(
                 "users",
@@ -96,66 +104,69 @@ class TestMongo(unittest.TestCase):
         self.db_users.close()
         return super().tearDown()
 
-    def test_db_connect(self):
-        """
-        try to connect
-        """
+    # def test_db_connect(self):
+    #     """
+    #     try to connect
+    #     """
 
-        self.db_users.create_table()
-        self.db_animals.create_table()
-        self.db_users.drop()
-        self.db_animals.drop()
+    #     self.db_users.create_table()
+    #     self.db_animals.create_table()
+    #     self.db_users.drop()
+    #     self.db_animals.drop()
 
-        u0 = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
-        u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
-        u2 = self._backoffice.users.create(
-            {"name": "benji", "surname": "benjie", "male": False}
-        )
+    #     u0 = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
+    #     u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
+    #     u2 = self._backoffice.users.create(
+    #         {"name": "benji", "surname": "benjie", "male": False}
+    #     )
 
-        # u0_ = backoffice.users.new()
-        # u0_.load(u0._id)
-        # print(u0_)
-        # u1_ = backoffice.users.new()
-        # u1_.load(u1._id)
-        # print(u1_)
-        # u2_ = backoffice.users.new()
-        # u2_.load(u2._id)
-        # print(u2_)
+    #     # u0_ = backoffice.users.new()
+    #     # u0_.load(u0._id)
+    #     # print(u0_)
+    #     # u1_ = backoffice.users.new()
+    #     # u1_.load(u1._id)
+    #     # print(u1_)
+    #     # u2_ = backoffice.users.new()
+    #     # u2_.load(u2._id)
+    #     # print(u2_)
 
-        a0 = self._backoffice.animals.create(
-            {
-                "surname": "cookie",
-                "type": "dog",
-                "user": u0._id,
-                "love": [u0._id, u1._id, u2._id],
-            }
-        )
-        a1 = self._backoffice.animals.create(
-            {"surname": "pioo", "type": "bird", "user": u0._id, "love": [u0._id]}
-        )
+    #     a0 = self._backoffice.animals.create(
+    #         {
+    #             "surname": "cookie",
+    #             "type": "dog",
+    #             "user": u0._id,
+    #             "love": [u0._id, u1._id, u2._id],
+    #         }
+    #     )
+    #     a1 = self._backoffice.animals.create(
+    #         {"surname": "pioo", "type": "bird", "user": u0._id, "love": [u0._id]}
+    #     )
 
-        u3 = self._backoffice.users.create(
-            {"name": "jean", "surname": "valjean", "is_loved_by": [a1._id]}
-        )
+    #     u3 = self._backoffice.users.create(
+    #         {"name": "jean", "surname": "valjean", "is_loved_by": [a1._id]}
+    #     )
 
-        print("RELOAD !!!!")
-        # a1.reload()
-        b = self._backoffice.animals.new()
-        b.load(a1._id)
+    #     print("RELOAD !!!!")
+    #     # a1.reload()
+    #     b = self._backoffice.animals.new()
+    #     b.load(a1._id)
 
-        print(a0.select("$.user.name"))
-        print(a1.select("$.user.name"))
+    #     print(a0.select("$.user.name"))
+    #     print(a1.select("$.user.name"))
 
-        print(f"{a0['surname']} loves ")
-        print(a0.select("$.love.name"))
+    #     print(f"{a0['surname']} loves ")
+    #     print(a0.select("$.love.name"))
 
-        print(f"{b['surname']} loves ")
-        print(b.select("$.love.name"))
-        print(f"{u3['surname']} is loved by ")
-        print(f"{u3.select("$.is_loved_by.surname")}")
+    #     print(f"{b['surname']} loves ")
+    #     print(b.select("$.love.name"))
+    #     print(f"{u3['surname']} is loved by ")
+    #     print(f"{u3.select("$.is_loved_by.surname")}")
 
-        # x_ = backoffice.users.new()
-        # x_.load("plop")
+    #     # x_ = backoffice.users.new()
+    #     # x_.load("plop")
+
+    def test_one_to_many(self):
+        pass
 
     def test_many_to_many(self):
         """

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -83,3 +83,5 @@ class TestMongo(unittest.TestCase):
         w_ = backoffice.users.new()
         w_.load(w._id)
         print(w_)
+        x_ = backoffice.users.new()
+        x_.load("plop")

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -28,16 +28,10 @@ class TestMongo(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
         # --- DB for user
-        self.db_users = DBSQLConnector(
-            collection="Users",
-            path="sqlite_test_db"
-        )
+        self.db_users = DBSQLConnector(collection="Users", path="sqlite_test_db")
 
         # --- DB for sites
-        self.db_site = DBSQLConnector(
-            collection="Sites",
-            path="sqlite_test_db"
-        )
+        self.db_site = DBSQLConnector(collection="Sites", path="sqlite_test_db")
 
     def tearDown(self):
         self.db_site.close()
@@ -57,10 +51,9 @@ class TestMongo(unittest.TestCase):
                 Item(
                     {"name": String(), "surname": String(), "male": Bool(default=True)}
                 ),
-                self.db_users
+                self.db_users,
             )
         )
-        
 
         # ignore sessions for this campaign of tests.
         current_user.standalone = True
@@ -70,8 +63,10 @@ class TestMongo(unittest.TestCase):
 
         # print(json.dumps(backoffice.users.get_meta(), indent=4))
         self.db_users.create_table(backoffice.users.get_meta())
-        # u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        # self.db_users.drop()
+
+        u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        # print(u.name)
+        # u.name = "bobi"
         # v = backoffice.users.new()
-        # u.save()
         # v.load(u._id)
-        self.db_users.drop()

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -5,13 +5,11 @@ test for CRUD()
 # pylint: disable=wrong-import-position, no-member, import-error, protected-access, wrong-import-order, duplicate-code
 
 import unittest
-import time
-import json
 
 
 from backo import Item, Collection
 from backo import DBSQLConnector
-from backo import Backoffice, NotFoundError, DBError, current_user
+from backo import Backoffice, current_user
 
 from backo import String, Bool  # , Error as StrictoError
 
@@ -65,7 +63,7 @@ class TestMongo(unittest.TestCase):
         self.db_users.create_table(backoffice.users.get_meta())
         # self.db_users.drop()
 
-        u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
+        # u = backoffice.users.create({"name": "bebert", "surname": "bebert"})
         # print(u.name)
         # u.name = "bobi"
         # v = backoffice.users.new()

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -33,6 +33,7 @@ class TestMongo(unittest.TestCase):
                 "surname": String(),
                 "male": Bool(default=True),
                 "animals": RefsList(coll="animals", field="$.user"),
+                "is_loved_by": RefsList(coll="animals", field="$.love"),
             }
         )
 
@@ -41,23 +42,25 @@ class TestMongo(unittest.TestCase):
                 "surname": String(),
                 "type": String(),
                 "user": Ref(coll="users", field="$.animals", required=True),
+                "love": RefsList(coll="users", field="$.is_loved_by"),
             }
         )
 
         self._meta = {}
-        self._meta["Users"] = user_item.get_schema()
-        self._meta["Animals"] = animal_item.get_schema()
-        self._user_meta = user_item.get_schema()
-        self._animal_meta = animal_item.get_schema()
+        self._meta["users"] = user_item.get_schema()
+        self._meta["animals"] = animal_item.get_schema()
 
-        print(json.dumps(self._user_meta, indent=4))
-        print(json.dumps(self._animal_meta, indent=4))
+        print(json.dumps(self._meta, indent=4))
 
         # --- DB for user
-        self.db_users = DBSQLConnector(collection="Users", path="sqlite_test_db", meta=self._meta)
+        self.db_users = DBSQLConnector(
+            collection="users", path="sqlite_test_db", meta=self._meta
+        )
 
         # --- DB for sites
-        self.db_animals = DBSQLConnector(collection="Animals", path="sqlite_test_db", meta=self._meta)
+        self.db_animals = DBSQLConnector(
+            collection="animals", path="sqlite_test_db", meta=self._meta
+        )
 
         self._backoffice.register_collection(
             Collection(
@@ -91,19 +94,16 @@ class TestMongo(unittest.TestCase):
         try to connect
         """
 
-
-
-
         self.db_users.create_table()
         self.db_animals.create_table()
         self.db_users.drop()
         self.db_animals.drop()
 
         u0 = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
-        u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
-        u2 = self._backoffice.users.create(
-            {"name": "benji", "surname": "benjie", "male": False}
-        )
+        # u1 = self._backoffice.users.create({"name": "ted", "surname": "teddy"})
+        # u2 = self._backoffice.users.create(
+        #     {"name": "benji", "surname": "benjie", "male": False}
+        # )
 
         # u0_ = backoffice.users.new()
         # u0_.load(u0._id)
@@ -115,11 +115,15 @@ class TestMongo(unittest.TestCase):
         # u2_.load(u2._id)
         # print(u2_)
 
-        a0 = self._backoffice.animals.create({"surname": "cookie", "type": "dog", "user": u0._id})
-        a1 = self._backoffice.animals.create({"surname": "pioo", "type": "bird", "user": u0._id})
+        a0 = self._backoffice.animals.create(
+            {"surname": "cookie", "type": "dog", "user": u0._id}
+        )
+        a1 = self._backoffice.animals.create(
+            {"surname": "pioo", "type": "bird", "user": u0._id}
+        )
 
-        
         print(a0.select("$.user.name"))
+        print(a1.select("$.user.name"))
 
         # x_ = backoffice.users.new()
         # x_.load("plop")

--- a/tests/test_sql_connector.py
+++ b/tests/test_sql_connector.py
@@ -51,6 +51,7 @@ class TestSQLiteConnector(unittest.TestCase):
                 "male": Bool(default=True),
                 "animals": RefsList(coll="animals", field="$.user"),
                 "is_loved_by": RefsList(coll="animals", field="$.love"),
+                # "totem": Ref(coll="animals", field="$.user"),
                 "location": Dict(
                     {
                         "country": String(),
@@ -70,6 +71,7 @@ class TestSQLiteConnector(unittest.TestCase):
                 "type": String(),
                 "user": Ref(coll="users", field="$.animals", required=True),
                 "love": RefsList(coll="users", field="$.is_loved_by"),
+                # "totem_of": Ref(coll="humans", field="$.totem"),
             }
         )
 
@@ -240,6 +242,43 @@ class TestSQLiteConnector(unittest.TestCase):
         Test one to many relationship
         """
 
+        log.debug("# Clean up drop tables")
+
+        self.db_users.drop_table()
+        self.db_animals.drop_table()
+        self.db_types.drop_table()
+
+        log.debug("# Create tables")
+
+        self.db_users.create_table()
+        self.db_animals.create_table()
+        self.db_types.create_table()
+
+        bebert = self._backoffice.users.create({"name": "bebert", "surname": "bebert"})
+
+        cookie = self._backoffice.animals.create(
+            {
+                "surname": "cookie",
+                "type": "dog",
+                "user": bebert._id,
+                "love": [bebert._id],
+            }
+        )
+
+        pioupiou = self._backoffice.animals.create(
+            {
+                "surname": "pioupiou",
+                "type": "bird",
+                "user": bebert._id,
+                "love": [bebert._id],
+            }
+        )
+
+        log.debug("# Reload bebert")
+        bebert.reload()
+        self.assertIn(pioupiou._id, bebert.animals)
+        self.assertIn(cookie._id, bebert.animals)
+
     def test_many_to_many(self):
         """
         Test many to many relationship
@@ -286,3 +325,6 @@ class TestSQLiteConnector(unittest.TestCase):
 
         self.assertEqual(len(cookie.love), 3)
         self.assertEqual(len(benji.is_loved_by), 1)
+
+    def test_nested_many_death_test(self):
+        """Test of nested of nested of relation ship of the death metal !"""


### PR DESCRIPTION
This PR solve #9 create a Database connector for SQLite

What works:  
 - Create tables given a schema
 - Drop tables given a schema
 - Drop all data from tables
 - Create (scalar, one-to-many, many-to-many)
 - Get by Id (scalar, one-to-many, many-to-one, many-to-many)
 - Delete by Id (not well tested, delete in cascade with on intermediate table from many-to-many)

Limits:
 - `save` missing
 - migration missing
 - Behavior on many-to-one / one-to-many relationships on DELETE not tested !
 - Some conversion between SQL / Python types missing
 - Some cases in mapping between SQL row / Python object missing
 - Get / Set value to dict using JSON path don't parse array (ex: $.object[0].x)

Proof of concept. Not production ready.