### PR TITLE
DatabaseEngine based YAML connector

### DIFF
--- a/backo/yaml/connection.py
+++ b/backo/yaml/connection.py
@@ -1,0 +1,84 @@
+import pathlib
+from yaml import load, dump, Loader, Dumper
+from backo.utils.nested_data_path import find, update, delete
+
+from ..database.connection import DatabaseConnection
+from .request import (
+    YamlSearchRequest,
+    YamlSearchResponse,
+    YamlCreateRequest,
+    YamlCreateResponse,
+    YamlDeleteRequest,
+    YamlDeleteResponse,
+    YamlUpdateRequest,
+    YamlUpdateResponse,
+)
+from ..error import NotFoundError
+
+
+class YamlConnection(DatabaseConnection):
+    def __init__(self, file_path, yaml_path=[]):
+        """Connection to a YAML file.
+
+        :param file_path: Path to the YAML file
+        :param yaml_path: YAML path to objects considered by the connection
+        """
+        self.file_path = pathlib.Path(file_path)
+        self.yaml_path = yaml_path
+
+    def execute_search(self, yaml_search_request):
+        with open(self.file_path, "r") as yaml_database:
+            database = load(yaml_database.read(), Loader=Loader)
+            try:
+                return YamlSearchResponse(
+                    yaml_search_request.path,
+                    # The request search path is relative to the base YAML path
+                    find(database, self.yaml_path + yaml_search_request.path)
+                )
+            except KeyError as e:
+                raise NotFoundError(
+                    f"Object with id {yaml_search_request.path} not found in YAML file {self.file_path}"
+                )
+
+    def execute_create(self, yaml_create_request):
+        database = None
+        with open(self.file_path, "r") as yaml_database:
+            # Init database as an empty dict if the file is empty
+            database = load(yaml_database.read(), Loader=Loader) or {}
+
+        # The path of the item to update is relative to the base YAML path
+        update(database, self.yaml_path + yaml_create_request.path, yaml_create_request.value)
+
+        with open(self.file_path, "w") as yaml_database:
+            yaml_database.write(dump(database, Dumper=Dumper))
+        return YamlCreateResponse(yaml_create_request.created_id)
+
+    def execute_delete(self, yaml_delete_request):
+        database = None
+        with open(self.file_path, "r") as yaml_database:
+            # Init database as an empty dict if the file is empty
+            database = load(yaml_database.read(), Loader=Loader) or {}
+
+        try:
+            # The path of the item to delete is relative to the base YAML path
+            delete(database, self.yaml_path + yaml_delete_request.path)
+        except KeyError:
+            # Deleting an object that do not exist is not an error
+            pass
+
+        with open(self.file_path, "w") as yaml_database:
+            yaml_database.write(dump(database, Dumper=Dumper))
+        return YamlDeleteResponse()
+
+    def execute_update(self, yaml_update_request):
+        database = None
+        with open(self.file_path, "r") as yaml_database:
+            # Init database as an empty dict if the file is empty
+            database = load(yaml_database.read(), Loader=Loader) or {}
+
+        # The path of the item to update is relative to the base YAML path
+        update(database, self.yaml_path + yaml_update_request.path, yaml_update_request.value)
+
+        with open(self.file_path, "w") as yaml_database:
+            yaml_database.write(dump(database, Dumper=Dumper))
+        return YamlDeleteResponse()

--- a/backo/yaml/engine.py
+++ b/backo/yaml/engine.py
@@ -1,0 +1,8 @@
+from ..database.engine import DatabaseEngine
+from .connection import YamlConnection
+from .item import YamlItem
+
+
+class YamlEngine(DatabaseEngine):
+    def __init__(self, file_path, yaml_path=[], database_item=YamlItem()):
+        super().__init__(YamlConnection(file_path, yaml_path), database_item)

--- a/backo/yaml/item.py
+++ b/backo/yaml/item.py
@@ -1,6 +1,9 @@
 import uuid
 
+from backo.utils.nested_data_path import find, update, delete
 from ..database.item import ItemMapper, DatabaseItem
+from ..database.attribute import DatabaseAttribute
+
 from .request import (
     YamlSearchRequest,
     YamlCreateRequest,
@@ -36,9 +39,47 @@ class MapByKey(ItemMapper):
     def load(self, base_search_response):
         return base_search_response.value
 
-
 class YamlItem(DatabaseItem):
     def __init__(
         self, item_mapper=MapByKey(), model={}
     ):
         super().__init__(item_mapper, model)
+
+class YamlAttribute(DatabaseAttribute):
+    def __init__(self, path):
+        """
+        :param attribute: Name of the field to load from the Yaml file
+        """
+        self.path = path
+
+    def search_request(self, base_request, _id):
+        # Nothing to do, the requested field will already be included in the
+        # response of the base_request, that include the complete object
+        # associated to _id
+        pass
+
+    def load(self, base_response, _attribute_response):
+        # _attribute_response is None, because no request was returned by
+        # search_request. But the field can be retrieved from the response of
+        # the base request
+        value = find(base_response.value, self.path)
+        # The value must be deleted from the response so this field is not
+        # included in the generated JSON-like dict
+        delete(base_response.value, self.path)
+        return value
+
+    def create_request(self, base_request: YamlCreateRequest, value):
+        # Adds the value of the attribute to the base create request
+        update(base_request.value, self.path, value)
+        # Removes the replaced path from the original user item
+        delete(base_request.value, self.attribute_path)
+
+    def update_request(self, base_request, _id, value):
+        # Adds the value of the attribute to the base create request
+        update(base_request.value, self.path, value)
+        # Removes the replaced path from the original user item
+        delete(base_request.value, self.attribute_path)
+
+    def delete_request(self, base_request, _id):
+        # Nothing to do, the complete item will be deleted by the base request
+        pass

--- a/backo/yaml/item.py
+++ b/backo/yaml/item.py
@@ -1,0 +1,44 @@
+import uuid
+
+from ..database.item import ItemMapper, DatabaseItem
+from .request import (
+    YamlSearchRequest,
+    YamlCreateRequest,
+    YamlDeleteRequest,
+    YamlUpdateRequest,
+)
+
+
+def uuid4():
+    return str(uuid.uuid4())
+
+
+class MapByKey(ItemMapper):
+    def __init__(self, generate_id=uuid4):
+        self.generate_id = generate_id
+
+    def created_id(self, yaml_create_response):
+        return yaml_create_response.created_id
+
+    def search_request(self, _id):
+        return YamlSearchRequest([_id])
+
+    def create_request(self, item_value):
+        _id = self.generate_id()
+        return YamlCreateRequest([_id], item_value, _id)
+
+    def delete_request(self, _id):
+        return YamlDeleteRequest([_id])
+
+    def update_request(self, _id, value):
+        return YamlUpdateRequest([_id], value)
+
+    def load(self, base_search_response):
+        return base_search_response.value
+
+
+class YamlItem(DatabaseItem):
+    def __init__(
+        self, item_mapper=MapByKey(), model={}
+    ):
+        super().__init__(item_mapper, model)

--- a/backo/yaml/request.py
+++ b/backo/yaml/request.py
@@ -1,0 +1,52 @@
+from typing import Any
+from dataclasses import dataclass
+
+
+@dataclass
+class YamlSearchRequest:
+    path: list[str|int]
+
+
+@dataclass
+class YamlSearchResponse:
+    # TODO: support exclude path. It can be safely removed from value even in a
+    # base response, because if an attribute needs it, it will still be included
+    # in its attribute response.
+    path: list[str|int]
+    value: Any
+
+
+@dataclass
+class YamlCreateRequest:
+    # TODO: support exclude path. Do not remove values from value as they might
+    # be needed to init item, but ignore them only when the request is executed.
+    # -> it's ok if the attributes removes it once it is done with it
+    path: list[str|int]
+    value: Any
+    created_id: str|None = None
+
+
+@dataclass
+class YamlCreateResponse:
+    created_id: str
+
+
+@dataclass
+class YamlDeleteRequest:
+    path: list[str|int]
+
+
+@dataclass
+class YamlDeleteResponse:
+    pass
+
+
+@dataclass
+class YamlUpdateRequest:
+    path: list[str|int]
+    value: Any
+
+
+@dataclass
+class YamlUpdateResponse:
+    pass

--- a/examples/yaml/attributes.py
+++ b/examples/yaml/attributes.py
@@ -1,0 +1,23 @@
+from backo.yaml.engine import YamlEngine
+from backo.yaml.item import YamlItem, YamlAttribute
+
+if __name__ == "__main__":
+    yaml_engine = YamlEngine(
+        "test.yaml", database_item=YamlItem(model={"login": YamlAttribute(["name"])})
+    )
+    item_id = yaml_engine.create(
+        {"login": "pipo", "gid": 12, "description": "Example user"}
+    )
+    print(f"Item {item_id} created.")
+    print(yaml_engine.search(item_id))
+    print()
+
+    yaml_engine.save(
+        item_id, {"login": "molo", "gid": 13, "description": "Updated user"}
+    )
+    print(f"Item {item_id} updated.")
+    print(yaml_engine.search(item_id))
+    print()
+
+    yaml_engine.delete(item_id)
+    print(f"Item {item_id} deleted.")

--- a/examples/yaml/create.py
+++ b/examples/yaml/create.py
@@ -1,0 +1,9 @@
+from backo.yaml.engine import YamlEngine
+
+if __name__ == "__main__":
+    yaml_engine = YamlEngine("test.yaml")
+    item_id = yaml_engine.create(
+        {"name": "pipo", "gid": 12, "description": "Example user"}
+    )
+    print(f"Item {item_id} created.")
+    print(yaml_engine.search(item_id))

--- a/examples/yaml/delete.py
+++ b/examples/yaml/delete.py
@@ -1,0 +1,12 @@
+from backo.yaml.engine import YamlEngine
+
+if __name__ == "__main__":
+    yaml_engine = YamlEngine("test.yaml")
+    item_id = yaml_engine.create(
+        {"name": "pipo", "gid": 12, "description": "Example user"}
+    )
+    print(f"Item {item_id} created.")
+    print(yaml_engine.search(item_id))
+
+    yaml_engine.delete(item_id)
+    print(f"Item {item_id} deleted.")

--- a/examples/yaml/search.py
+++ b/examples/yaml/search.py
@@ -1,0 +1,15 @@
+import yaml
+
+from backo.yaml.engine import YamlEngine
+
+def init_data(path):
+    with open(path, "w") as yaml_file:
+        yaml_file.write(
+            yaml.dump({"1": {"name": "pipo", "gid": 12, "description": "Example user"}})
+        )
+
+if __name__ == "__main__":
+    init_data("test.yaml")
+
+    yaml_engine = YamlEngine("test.yaml")
+    print(yaml_engine.search("1"))

--- a/examples/yaml/update.py
+++ b/examples/yaml/update.py
@@ -1,0 +1,17 @@
+from backo.yaml.engine import YamlEngine
+
+if __name__ == "__main__":
+    yaml_engine = YamlEngine("test.yaml")
+    item_id = yaml_engine.create(
+        {"name": "pipo", "gid": 12, "description": "Example user"}
+    )
+    print(f"Item {item_id} created.")
+    print(yaml_engine.search(item_id))
+
+    item = yaml_engine.search(item_id)
+    item["name"] = "molo"
+    item["description"] = "Updated user"
+
+    yaml_engine.save(item_id, item)
+    print(f"Item {item_id} updated.")
+    print(yaml_engine.search(item_id))


### PR DESCRIPTION
Demonstrates how a custom YAML connector can be implemented from the DatabaseEngine framework.

Should be merged on main if #15 is merged before, when all YAML features and required attributes are implemented. 